### PR TITLE
Handle case where package.json exists but not .dat

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 var path = require('path')
 var meta = require(path.join(__dirname, 'lib', 'meta.js'))
+var commands = require(path.join(__dirname, 'lib', 'commands'))
 
 module.exports = Dat
 
@@ -41,8 +42,15 @@ function Dat(dir, opts, onReady) {
   
   this.meta = meta(this.dir, function(err) {
     if (err) return onReady()
-    self._storage(opts, onReady)
+    commands._ensureExists(opts, function (err) {
+      if (err) {
+        console.error(err)
+        process.exit(1)
+      }
+
+      self._storage(opts, onReady)
+    })
   })
 }
 
-Dat.prototype = require(path.join(__dirname, 'lib', 'commands'))
+Dat.prototype = commands


### PR DESCRIPTION
If you run `dat` in a directory that contains a valid `package.json` but not a `.dat` subdirectory you get this error:

```
events.js:72
        throw er; // Unhandled 'error' event
              ^
OpenError: IO error: /home/beau/p/dat/.dat/store.dat/LOCK: No such file or directory
    at /home/beau/p/dat/node_modules/level-hyper/node_modules/level-packager/node_modules/levelup/lib/levelup.js:114:34
```

This pull request fixes that error and displays the error message from `dat._ensureExists` in its place:

```
Error: You are not in a dat folder or are missing a package.json. Please run dat init again.
```
