### PR TITLE
`dat serve` prints URL of the running server

### DIFF
--- a/lib/commands.js
+++ b/lib/commands.js
@@ -169,7 +169,7 @@ dat.serve = function(options, cb) {
   // if already listening then return early w/ success callback
   if (this._server && this._server.address()) {
     setImmediate(function() {
-      cb(null, 'Listening on ' + self._server.address().port)
+      cb(null, 'Listening on http://localhost:' + self._server.address().port)
     })
     return
   }


### PR DESCRIPTION
This means that users can cmd-click the URL, and it will open in their browser!
