### PR TITLE
Do not sort existing columns in getNewColumns

### DIFF
--- a/lib/meta.js
+++ b/lib/meta.js
@@ -61,7 +61,7 @@ Meta.prototype.addColumns = function(columns, cb) {
 
 Meta.prototype.getNewColumns = function(b, opts) {
   if (!opts) opts = { strict: false }
-  var existing = this.json.columns
+  var existing = [].concat(this.json.columns)
     
   // remove reserved columns
   var incoming = []


### PR DESCRIPTION
This fixes a bug where existing columns would get sorted when computing new column fields. This leads to data getting shifted around when reading.

To reproduce the issue simply do

``` js
var ws = dat.createWriteStream({objects:true, primary:['a']});
ws.write({b:'b', a:'a'});
ws.end();
```

When reading the data back again it will look like this

``` js
{
  _id: 'a',
  _rev: '1-a6762558fc027caeb14eb1d1ffca8e9f',
  b: 'a',
  a: 'b'
}
```

The fix is simply copying the columns array before sorting it. I'm pretty sure this also fixes #54
