### PR TITLE
Use isatty instead if process.stdin.isTTY

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ var getPort = require(path.join(__dirname, 'lib', 'get-port'))
 var backend = require(path.join(__dirname, 'lib', 'backend'))
 var request = require('request').defaults({json: true})
 var fs = require('fs')
+var tty = require('tty')
 
 module.exports = Dat
 
@@ -65,7 +66,7 @@ function Dat(dir, opts, onReady) {
         loadMeta()
       })
     }
-    if (!process.stdin.isTTY) setTimeout(read, 2000)
+    if (!tty.isatty(0)) setTimeout(read, 2000)
     else read()
   }
   


### PR DESCRIPTION
Currently dat has an issue if you do some like

```
cd big-repo
dat cat | cat -
```

The output will end almost instantly because of an `EPIPE` error being emitted on stdout.
This is actually caused by some weirdish node behaviour (see joyent/node#7481) because we use `process.stdin.isTTY` to check wether or not stdin is a TTY.

This PR adds a quick and dirty workaround by using `tty.isatty(0)` to check if stdin is a tty.
