### PR TITLE
forward cat options to readstream

### DIFF
--- a/lib/commands.js
+++ b/lib/commands.js
@@ -359,7 +359,7 @@ dat.cat = function(options, cb) {
   logger.on('error', function(e){
     console.error('logger err', e)
   })
-  var readStream = this.createReadStream()
+  var readStream = this.createReadStream(options)
   readStream.pipe(logger).pipe(stdout)
   readStream.on('end', cb)
   readStream.on('error', cb)


### PR DESCRIPTION
allows us to stuff like `dat cat --csv`
