### PR TITLE
Bump stdout-stream to 1.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "stream-combiner": "~0.0.2",
     "sublevel": "~2.3.0",
     "through2": "~0.4.1",
-    "stdout-stream": "~1.1.0"
+    "stdout-stream": "~1.2.0"
   },
   "directories": {
     "example": "examples",


### PR DESCRIPTION
stdout-stream 1.2.0 has full windows support
