### PR TITLE
add usage info for --csv options

### DIFF
--- a/usage.md
+++ b/usage.md
@@ -18,8 +18,18 @@ echo '{"hello": "world"}' | dat --json
 
 ```
 cat some_csv.csv | dat import --csv
-custom delimiter, --delimiter works too
-cat some_csv.csv | dat import --csv -d $'\r\n'
+```
+
+use a custom newline delimiter:
+
+```
+cat some_csv.csv | dat import --csv --newline $'\r\n'
+```
+
+use a custom value separator:
+
+```
+cat some_tsv.tsv | dat import --csv --separator $'\t'
 ```
 
 ## specify a primary key to use


### PR DESCRIPTION
A few minor edits for the CSV section indicating how you can specify a custom newline delimiter with `--newline` or a custom value separator with `--separator`.  The latter is particularly handy if you want to import TSV (tab-separated value) files.  Note that these options get passed directly to `binary-csv`, which handles CSV parsing.
