### PR TITLE
Write streamed rows using standard put method

### DIFF
--- a/lib/storage.js
+++ b/lib/storage.js
@@ -131,7 +131,7 @@ Database.prototype.put = function (rawDoc, buffer, opts, cb) {
   var self = this
   var doc = rawDoc
   var updated
-  
+
   if (bops.is(rawDoc)) {
     cb = opts
     opts = buffer
@@ -152,7 +152,9 @@ Database.prototype.put = function (rawDoc, buffer, opts, cb) {
     cb = opts
     opts = {}
   }
-  
+
+  opts.meta = opts.meta || {}
+
   var columns = Object.keys(doc)
   if (opts.columns) columns = columns.concat(opts.columns)
   var newColumns = this.meta.getNewColumns(columns)
@@ -166,12 +168,16 @@ Database.prototype.put = function (rawDoc, buffer, opts, cb) {
   
   function check() {
     // TODO implement primary + hash options from writeStream here
-
+    if (opts.meta._id) doc._id = opts.meta._id
     if (opts.overwrite || !doc._id) return store()
     
     debug('check', doc._id)
     self.get(doc._id, function(err, existing) {
       if (err) return store()
+      if (opts.meta._rev) {
+        doc = existing
+        return store()
+      }
       if (!doc._rev || doc._rev[0] < existing._rev[0]) return cb(self.errors.conflict())
       store()
     })

--- a/lib/write-stream.js
+++ b/lib/write-stream.js
@@ -296,20 +296,7 @@ WriteStream.prototype.setPrimaryIndex = function(columns) {
 }
 
 WriteStream.prototype.onWrite = function (rows, enc, done) {
-  var self = this
-  var options = this.options
-  if (options.overwrite) {
-    self.writeBatch(rows, done)
-  } else {
-    self.checkRows(rows, function(errs, updatedRows) {
-      if (errs) {
-        self.writeStream.emit('error', errs)
-        done()
-        return
-      }
-      self.writeBatch(updatedRows, done)
-    })
-  }
+  this.writeBatch(rows, done)
 }
 
 WriteStream.prototype.onEnd = function (done) {
@@ -318,117 +305,42 @@ WriteStream.prototype.onEnd = function (done) {
   done()
 }
 
-WriteStream.prototype.checkRows = function (rows, cb) {
-  var self = this
-  var len = rows.length
-  var pending = len
-  var results = []
-  var errors = []
-  var store = this.store
-
-  for (var i = 0; i < len; i++) {
-    var key = this.primaryKeyAt(i)
-    store.get(key._id, onRow)
-  }
-  
-  function onRow(err, row) {
-    results.push([err, row])
-    pending--
-    if (pending === 0) finish()
-  }
-  
-  function finish() {
-    for (var i = 0; i < results.length; i++) {
-      var err = results[i][0]
-      var row = results[i][1]
-      var result = {}
-      if (err && typeof err.notFound === 'undefined') {
-        result.key = key
-        result.error = err.message
-        errors.push(result)
-      }
-      if (row) {
-        var rev = self.primaryKeyAt(i)._rev || ''
-        var existing = row
-        if (!rev || rev[0] < existing._rev[0]) {
-          result.key = key
-          result.error = self.dat.storage.errors.conflict()
-          errors.push(result)
-        } else {
-          result._rev = row._rev
-          result.buffer = rows[i]
-          rows[i] = result
-        }
-      }
-    }
-    cb(errors.length > 0 ? errors : null, rows)
-  }
-}
-
 WriteStream.prototype.writeBatch = function (rows, cb) {
-  debug('writeBatch', rows.length)
-  var self = this
-  var options = this.options
-  var store = this.store
   var len = rows.length
   var pending = len
+  var meta
+  var self = this
+  debug('writeBatch', rows.length)
   if (pending > 0) self.writing = true
-  var batch = []
-  
+
+  function batchDone() {
+    debug('writeBatch finished', len)
+    self.writing = false
+    cb()
+    if (self.ended) self.writeStream.push(null)
+  }
+
+  function rowDone(err, updated) {
+    if (err) return self.writeStream.emit('error', err)
+    self.writeStream.push({success: true, row: updated})
+    pending--
+    if (pending === 0) batchDone()
+  }
+
   for (var i = 0; i < len; i++) {
-    var row = rows[i]
-    var doc = {}
-    
-    if (row._rev) {
-      doc._rev = row._rev
-      row = row.buffer
-    }
-    
-    if (this.primary) {
-      doc._id = this.primaryKeyAt(0)._id
-      this.primaryKeys.shift()
-    }
-    
-    var meta = docUtils.updateRevision(doc, row, self.meta.json.columns)
-    
-    if (!meta) {
-      rows[i] = {success: true, row: doc, existed: true}
-      pending--
-      if (pending === 0) commit()
-      continue
-    }
-    
-    var seq = store.seq = store.seq + 1
-    var keys = docUtils.rowKeys(store.keys, store.sep, meta._id, meta._rev, seq, meta._deleted)
-    
+    meta = null
+    row = rows[i]
+
+    // TODO: test for this
     if (row.length === 0) row = whiteSpace
 
-    batch.push({ type: 'put', key: keys.seq, value: JSON.stringify([seq, meta._id, meta._rev]) })
-    batch.push({ type: 'put', key: keys.row, value: row })
-    // TODO handle updating non-latest rows
-    batch.push({ type: 'put', key: keys.cur, value: docUtils.packRevision(meta._rev) })
-    
-    rows[i] = {success: true, row: meta}
-    
-    pending--
-    if (pending === 0) commit()
-  }
-
-  function commit() {
-    if (batch.length === 0) return next()
-    
-    store.db.batch(batch, function(err) {
-      debug('writeBatch finished', len)
-      if (err) console.error('batch write err', err)
-      next()
-    })
-    
-    function next() {
-      self.writing = false
-      for (var i = 0; i < len; i++) self.writeStream.push(rows[i])
-      store.incRowCount(rows.length, cb)
-      if (self.ended) self.writeStream.push(null)
+    if (this.primary) {
+      meta = this.primaryKeyAt(0)
+      this.primaryKeys.shift()
     }
+
+    // TODO: overwrite works (again)
+    this.dat.put(row, {meta: meta}, rowDone)
   }
 }
 

--- a/test/tests/write-streams.js
+++ b/test/tests/write-streams.js
@@ -555,6 +555,33 @@ module.exports.keepTotalRowCount = function(test, common) {
 
     })
   })
+
+  test('keeps row count for streams after updates', function(t) {
+    common.getDat(t, function(dat, done) {
+      var ws1 = dat.createWriteStream({ json: true })
+
+      ws1.on('end', function() {
+        var ws2 = dat.createWriteStream({ json: true })
+
+        ws2.on('error', function(e) {
+          var cat = dat.createReadStream()
+
+          cat.pipe(concat(function(data) {
+            t.equal(data.length, 1)
+            t.equal(dat.getRowCount(), 1)
+            done()
+          }))
+        })
+
+        ws2.write(bops.from(JSON.stringify({'_id': 'foo'})))
+        ws2.end()
+      })
+
+      ws1.write(bops.from(JSON.stringify({'_id': 'foo'})))
+      ws1.end()
+
+    })
+  })
 }
 
 


### PR DESCRIPTION
This makes it such that rows being added from a write stream are added via the same put method that dat normally uses. The mutex can then take care of batching etc.: https://github.com/mikeal/level-mutex/blob/master/index.js#L118 This should consolidate logic hopefully?

As an added bonus, when rows are updated via the write stream, the row count remains accurate!
