### PR TITLE
Print progress info

### DIFF
--- a/lib/commands.js
+++ b/lib/commands.js
@@ -273,7 +273,9 @@ dat.push = function(options, cb) {
       this.push(JSON.stringify(obj.data) + '\n')
       next()
     })
-    readStream.pipe(serializer).pipe(post).pipe(stdout)
+
+    readStream.pipe(serializer)
+    dat.printProgress(serializer, post, { verb: 'pushed' })
     post.on('end', cb)
     post.on('error', cb)
   })
@@ -311,21 +313,13 @@ dat.pull = function(options, cb) {
           debug('pull', remote + '/_changes')
           var pullStream = store.createPullStream(remote + '/_changes', options)
           
-          var progStream = progress({
-            time: 1000,
-            objectMode: true
-          })
-          
-          progStream.on('progress', function(meta) {
-            clearLog('Pulling from _changes feed. Elapsed: ' + meta.runtime + 's, Loaded: ' + meta.transferred + ' rows.\n')
-          })
                     
           pullStream.remote = remote
           obj.stream = pullStream
           
           var writeStream = self.createWriteStream({ objects: true, overwrite: false, batchTime: 250 })
           
-          pullStream.pipe(progStream).pipe(writeStream)
+          dat.printProgress(pullStream, writeStream, { verb: 'pulled' })
           
           pullStream.on('error', function(e) {
             writeStream.end()
@@ -611,3 +605,40 @@ dat.supportsLiveBackup = function() {
   var isHyper = !!leveldown.liveBackup
   return isHyper
 }
+
+dat.printProgress = function(readable, writeable, opts) {
+  opts = opts || {}
+  if (opts.quiet) {
+    readable.pipe(writeable)
+  } else if (opts.verbose) {
+    readable.pipe(writeable).pipe(resultPrinter())
+  } else {
+    readable.pipe(progressPrinter(opts)).pipe(writeable)
+  }
+}
+
+function resultPrinter() {
+  var results = through.obj(onResultWrite)
+  function onResultWrite (obj, enc, next) {
+    if (obj.success) process.stdout.write(JSON.stringify(obj.row) + EOL)
+    else process.stderr.write(JSON.stringify(obj) + EOL)
+    next()
+  }
+  return results
+}
+
+function progressPrinter(opts) {
+  var progStream = progress({ objectMode: true })
+  var verb = (opts || {}).verb || 'transferred'
+
+  function logProg(runtime, transferred) {
+    if (runtime === 0) return clearLog(transferred + ' rows ' + verb + ' in less than a second' + EOL)
+    clearLog(transferred + ' rows ' + verb + '. Elapsed: ' + runtime + 's. ' + Math.floor(transferred / runtime) + ' rows/second' + EOL)
+  }
+
+  progStream.on('progress', function(meta) {
+    logProg(meta.runtime, meta.transferred)
+  })
+  return progStream
+}
+

--- a/lib/parse-cli.js
+++ b/lib/parse-cli.js
@@ -1,7 +1,4 @@
-var EOL = require('os').EOL
-var through = require('through2')
 var fs = require('fs')
-var path = require('path')
 var tty = require('tty')
 var debug = require('debug')('dat.parseCLI')
 
@@ -13,8 +10,13 @@ module.exports = {
 
 function writeInputStream(inputStream, dat, opts) {
   var writer = dat.createWriteStream(opts)
-  inputStream.pipe(writer)
-  if (!opts.argv.quiet) writer.pipe(resultPrinter())
+
+  dat.printProgress(inputStream, writer, {
+    quiet: opts.argv.quiet,
+    verb: 'imported',
+    verbose: opts.argv.verbose
+  })
+
   writer.on('end', function() {
     dat.close()
   })
@@ -30,31 +32,31 @@ function getInputStream(opts, cmd) {
   var first = opts._[0] || ''
   var second = opts._[1] || ''
   var isTTY = tty.isatty(0)
-  
+
   debug('getInputStream', 'isTTY=' + isTTY, 'opts=' + JSON.stringify(opts))
-  
+
   // cat foo.txt | dat input, cat foo.txt | dat input -
   if ((!isTTY && second === '') || second === '-') {
     debug('using process.stdin as input')
     return process.stdin
   }
-  
+
   // cat foo.txt | dat input - w/o relying on isTTY
   if (first === 'import' && second === '') {
     console.log('using process.stidn as input due to import w/ no arguments')
     return process.stdin
   }
-  
+
   if (!second) return
-  
-  if (opts.csv 
+
+  if (opts.csv
     || opts.f === 'csv'
     || opts.json
     || opts.f === 'json') {
       debug('using fs.createReadStream', second, 'as input')
       return fs.createReadStream(second)
     }
-      
+
 }
 
 function command(opts) {
@@ -72,14 +74,4 @@ function command(opts) {
     options[arg] = opts.argv[arg]
   })
   return {command: cmd, options: options}
-}
-
-function resultPrinter() {
-  var results = through.obj(onResultWrite)
-  function onResultWrite (obj, enc, next) {
-    if (obj.success) process.stdout.write(JSON.stringify(obj.row) + EOL)
-    else process.stderr.write(JSON.stringify(obj) + EOL)
-    next()
-  } 
-  return results
 }

--- a/test/tests/cli.js
+++ b/test/tests/cli.js
@@ -34,7 +34,7 @@ module.exports.importCSV = function(test, common) {
           t.ok(stdo.indexOf('Initialized dat store') > -1, 'init ok')
           var testCsv = path.join(os.tmpdir(), 'test.csv')
           fs.writeFileSync(testCsv, 'a,b,c\n1,2,3\n4,5,6\n7,8,9')
-          var cmd = datCmd + ' import "' + testCsv + '" --csv'
+          var cmd = datCmd + ' import "' + testCsv + '" --csv --verbose'
           child.exec(cmd, {timeout: 20000, cwd: common.dat1tmp}, done)
           
           function done(err, stdo, stde) {


### PR DESCRIPTION
https://github.com/maxogden/dat/issues/83

Caveat; I opted not to log the progress at a time interval, tbh imports made things too choppy for that to work well.

Open to further suggestions on how this should work. Right now we don't log when a transfer job starts and when it ends, which could be helpful but could also become console clutter.
