### PR TITLE
cli.js: Document clone arguments (optional directory)

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -81,7 +81,13 @@ dat push http://localhost:6461
 
 ## grab all the NPM registry metadata
 
-With `dat clone <repository> [<directory>]`.  For example:
+With
+
+```
+dat clone <repository> [<directory>]
+```
+
+For example:
 
 ```
 dat clone http://dat-npm.mathiasbuus.eu


### PR DESCRIPTION
'dat clone' accepts an optional directory argument since 4fad9f4 (dat clone
works more like git clone now, 2014-04-10).  Mention that in the usage docs.

I'm not very familiar with the range of JavaScript libraries, but if there is
something similar to Python's argparse module that lets you declare your
interface and then automatically constructs the parser and usage docs, that
would make it easier to keep the parser and docs in sync.
