### PR TITLE
move stdout from devDependencies to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "single-line-log": "^0.3.1",
     "sleep-ref": "^1.1.0",
     "speedometer": "^0.1.2",
+    "stdout": "0.0.3",
     "stdout-stream": "~1.2.0",
     "stream-combiner": "~0.0.2",
     "stream-splicer": "^1.1.0",
@@ -81,7 +82,6 @@
   },
   "devDependencies": {
     "memdown": "^0.7.1",
-    "stdout": "0.0.3",
     "tape": "^2.13.2"
   },
   "browser": {


### PR DESCRIPTION
When installing dat as a dependency in another package (^v5.0.1), I got this error:

```
Error: Cannot find module 'stdout'
    at Function.Module._resolveFilename (module.js:338:15)
    at Function.Module._load (module.js:280:25)
    at Module.require (module.js:364:17)
    at require (module.js:380:17)
    at Object.<anonymous> (/Users/sethvincent/workspace/flatsheet/experiments/multi-dat/node_modules/dat/lib/transformations.js:9:14)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Module.require (module.js:364:17)
```

Moving stdout to the dependencies field in package.json fixes it.
