### PR TITLE
use a working version node on appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,11 +13,11 @@ version: "{build}"
 # what combinations to test
 environment:
   matrix:
-    - nodejs_version: 0.10
+    - nodejs_version: 0.10.29
 
-# Get the latest stable version of Node 0.STABLE.latest
+# Get the stable version of node
 install:
-  - ps: Update-NodeJsInstallation (Get-NodeJsLatestBuild $env:nodejs_version)
+  - ps: Update-NodeJsInstallation $env:nodejs_version
   - npm install
 
 build: off


### PR DESCRIPTION
0.10.30 is broken on appveyor, 0.10.29 is working however.
