### PR TITLE
Add DAT_PORT environmental variable to set dat serve port

### DIFF
--- a/lib/get-port.js
+++ b/lib/get-port.js
@@ -7,11 +7,12 @@ module.exports = getPort
 module.exports.readPort = readPort
 
 function getPort(startingPort, portFile, cb) {
+  if (process.env.DAT_PORT) { return cb(null, process.env.DAT_PORT)}
   readPort(portFile, function(err, port) {
     if (err) return newPort()
     gotPort(err, port)
   })
-  
+
   function newPort() {
     getport(startingPort, function(err, port) {
       if (err) return gotPort(err)
@@ -21,7 +22,7 @@ function getPort(startingPort, portFile, cb) {
       })
     })
   }
-  
+
   function gotPort(err, port) {
     if (err) {
       debug('err: ' + err)


### PR DESCRIPTION
Small needed change to play nice for example with Heroku (especially now that there's an [Heroku button](https://devcenter.heroku.com/articles/heroku-button))
Check [heroku-dat-template](https://github.com/bmpvieira/heroku-dat-template) for a demo.
