### PR TITLE
dat init - do not prompt if dat.json exists #148

### DIFF
--- a/lib/commands.js
+++ b/lib/commands.js
@@ -99,30 +99,28 @@ dat.init = function(options, cb) {
   fs.exists(paths.dat, function(exists) {
     if (exists) return cb(new Error("A dat store already exists here"))
 
-    var datjsonPath = path.join(paths.dat, '..', 'dat.json')
-    fs.exists(datjsonPath, function (jsonExists) {
+    fs.exists(paths.package, function (jsonExists) {
       if(jsonExists) {
-        initDat(options, cb)
-      } else {
-        initDatjson(datjsonPath, options, function (err) {
+        if(!options.quit) console.log('Using existing dat.json found in this directory')
+        self._mkdir(options, function (err) {
           if(err) return cb(err)
-          initDat(options, cb)
+          initStorage(options, cb)
+        })
+      } else {
+        initDatjson(paths.package, options, function (err) {
+          if(err) return cb(err)
+          initStorage(options, cb)
         })
       }
     })
   })
 
-  function initDat(options, cb) {
-    self._mkdir(options, function (err) {
-      if(err) return cb(err)
-      initStorage(options, cb)
-    })
-  }
-
   function initDatjson(datjsonPath, opts, cb) {
     prompt(opts, function(err) {
       if (err) return cb(err)
-      fs.writeFile(datjsonPath, JSON.stringify(json, null, 2)+EOL, cb)
+        self._mkdir(options, function (err) {
+          fs.writeFile(datjsonPath, JSON.stringify(json, null, 2)+EOL, cb)
+        })
     })
   }
   


### PR DESCRIPTION
Do not prompt for creating a `dat.json` if it already exists after `dat init`.

See #148
