### PR TITLE
Added 'Beginner tutorials about technologies used by dat' section to get...

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -36,3 +36,9 @@ To learn about how replication works in detail check out [our replication guide]
 To help build data pipelines with dat we have a complementary tool called [gasket](https://github.com/datproject/gasket).
 
 The best way to learn about gasket is to do the [data-plumber](https://www.npmjs.org/package/data-plumber) workshop.
+
+## Beginner tutorials about technologies used by dat
+
+ - [Node](https://github.com/maxogden/art-of-node#the-art-of-node)
+ - [RESTful Interface](http://stackoverflow.com/questions/671118/what-exactly-is-restful-programming)
+ - [Command Line](http://learncodethehardway.org/cli/book/cli-crash-course.html)


### PR DESCRIPTION
I'm not sure whose dat's audience is (I assume developers and early adopters at this point), but decided it would be helpful to add some basic links about the technologies used in dat (namely node, command line basics, and RESTful interface). The documentation as it stands now seems oriented more towards JavaScript and data admin developers.

Many people won't be able to use dat on day one. One way to keep a broader range of people engaged in dat is to provide them with tutorials to work on now so that they can be technically competent enough to take advantage of dat's features in the future. I know this issue is partially being addressed by offering a GUI, however I think it would be beneficial to encourage non-developers  to try to interact with dat's CLI interface. After all, learning UNIX and how the internet works is an important life skill :)
