### PR TITLE
Allow for HEAD REST requests for rows

### DIFF
--- a/lib/rest-handler.js
+++ b/lib/rest-handler.js
@@ -356,16 +356,21 @@ RestHandler.prototype.bulk = function(req, res) {
 
 RestHandler.prototype.document = function(req, res, opts) {
   var self = this
-  if (req.method === "GET") {
-    if (opts.key) return this.get(req, res, opts)
-    else return this.exportJson(req, res)
-  }
-  this.auth.handle(req, res, function(err) {
-    if (err) return self.auth.error(req, res)
-    if (req.method === "POST") return self.post(req, res, opts)
-    if (req.method === "DELETE") return self.delete(req, res, opts)
-    self.error(res, 405, {error: 'method not supported'})
-  })
+  if (req.method === 'HEAD') {
+    res.writeHead(200, {
+      'content-type': 'application/json',
+      'content-length': 0
+    })
+    res.end();
+  } else if (req.method === 'POST' || req.method === 'DELETE')
+    this.auth.handle(req, res, function(err) {
+      if (err) return self.auth.error(req, res)
+      if (req.method === 'POST') return self.post(req, res, opts)
+      if (req.method === 'DELETE') return self.delete(req, res, opts)
+      self.error(res, 405, {error: 'method not supported'})
+    })
+  else if (req.method === 'GET')
+    return (opts.key) ? this.get(req, res, opts) : this.exportJson(req, res)
 }
 
 RestHandler.prototype.bufferJSON = function(req, cb) {


### PR DESCRIPTION
A proper handling of `HEAD` requests in the REST API. Builds on Finn's insights in #181 and supersedes it.
