### PR TITLE
Extended response from '/api' route (description and publisher)

### DIFF
--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -28,6 +28,8 @@ Returns JSON about this dat. Example:
 - `version` is the dat version from dat's package.json
 - `changes` is the latest change sequence number (used for replication)
 - `name` is taken from the dat.json name field if present
+- `description` is taken from the dat.json description field if present
+- `publisher` is taken from the dat.json publisher field if present
 - `rows` is the number of rows in the dat tabular store
 
 ## GET /api/rows

--- a/lib/rest-handler.js
+++ b/lib/rest-handler.js
@@ -266,7 +266,9 @@ RestHandler.prototype.hello = function(req, res) {
     "dat": "Hello",
     "version": this.dat.version,
     "changes": this.dat.storage.change,
-    "name": this.dat.options.name
+    "name": this.dat.options.name,
+    "description": this.dat.options.description,
+    "publisher": this.dat.options.publisher
   }
 
   this.dat.storage.stat(function(err, stat) {


### PR DESCRIPTION
This PR extends the JSON response from the '/api' route. The response will also provide the `description` and `publisher` information from the `dat.json` (if available) then.

I thought this information could be useful for the upcoming `dat-editor2` (#195).

/André
