### PR TITLE
tests: fix running specific tests

### DIFF
--- a/test/run.js
+++ b/test/run.js
@@ -38,7 +38,7 @@ if (process.env['RPC']) {
 }
 
 if (specificTestFile) {
-  var testModule = require('./' + path.relative(__dirname, specificTestFile))
+  var testModule = require(path.resolve(__dirname, 'tests', specificTestFile))
   if (specificTest) testModule[specificTest](test, common)
   else testModule.all(test, common)
 } else {


### PR DESCRIPTION
I was looking into fixing tests on Windows and tried running tests individually. I ran into this:

``` shell
shama in ~/Documents/www/dat on master*
$ node test/run.js cli.js
Command not found: cli.js 

Usage: dat <command> [<args>]

Enter 'dat help' for help
shama in ~/Documents/www/dat on master*
$ node test/run.js tests/cli.js

/Users/Kyle/Documents/www/dat/node_modules/tape/index.js:75
        throw err
              ^
Error: Cannot find module './../tests/cli.js'
    at Function.Module._resolveFilename (module.js:338:15)
    at Function.Module._load (module.js:280:25)
    at Module.require (module.js:364:17)
    at require (module.js:380:17)
    at Object.<anonymous> (/Users/Kyle/Documents/www/dat/test/run.js:41:20)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Function.Module.runMain (module.js:497:10)

```

This PR will let you run tests specifically with `node test/run cli` on both unix/windows. Thanks!
