### PR TITLE
cli: replace calls to process.exit with exit as Windows workaround

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -10,10 +10,11 @@ var fs = require('fs')
 var path = require('path')
 var rimraf = require('rimraf')
 var debug = require('debug')('dat.cli')
+var exit = require('exit')
 
 var onerror = function(err) {
   console.error('Error: ' + err.message)
-  process.exit(2)
+  exit(2)
 }
 
 // rules:
@@ -52,7 +53,7 @@ var badMessage = ['Command not found: ' + cmd, '', defaultMessage].join(EOL)
 
 if (!bin.hasOwnProperty(first) && !bin.hasOwnProperty(cmd)) {
   console.error(first ? badMessage : defaultMessage)
-  process.exit(1)
+  exit(1)
 }
 
 var dir = (first === 'clone' && (argv._[2] || toFolder(argv._[1]))) || argv.path || '.' // leaky
@@ -67,7 +68,7 @@ var dat = Dat(dir, {init: false}, function(err) {
       if (err) {
         if (cmd === 'init') {
           console.error(err.message)
-          process.exit(0)
+          exit(0)
         }
         return onerror(err)
       }

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "duplexify": "^3.1.2",
     "end-of-stream": "^1.0.0",
     "execspawn": "^0.2.0",
+    "exit": "^0.1.2",
     "extend": "~1.2.1",
     "getport": "~0.1.0",
     "head-stream": "~0.0.4",


### PR DESCRIPTION
Ref: joyent/node#3584

On Windows, output isn't always flushed when exiting. This implements [exit](https://www.npmjs.org/package/exit) as a workaround to ensure output is flushed when exiting on Windows.

This fixes all but 3 tests on Windows. I'm still looking into those (looks like a pipe being destroyed early when ran via RPC):

![screen shot 2014-12-02 at 11 47 33 am](https://cloud.githubusercontent.com/assets/99604/5269620/2abf9048-7a19-11e4-9ef8-4fe1ee297ea3.png)
