### PR TITLE
detect .tsv file extension

### DIFF
--- a/bin/import.js
+++ b/bin/import.js
@@ -17,10 +17,16 @@ module.exports = function(dat, opts, cb) {
     if (!opts.quiet) console.error('No import file specified, using STDIN as input')
     input = process.stdin
   } else if (filename) {
-    if(!(opts.json || opts.csv)) {
+    if (!(opts.json || opts.csv)) {
       var ending = path.extname(filename)
-      if(ending === '.json') opts.json = true
-      else if(ending === '.csv') opts.csv = true
+      if (ending === '.json') {
+          opts.json = true;
+      } else if (ending === '.tsv') {
+          opts.csv = true;
+          opts.separator = '	';  // use tab separator
+      } else if (ending === '.csv') {
+          opts.csv = true;
+      }
     }
     input = fs.createReadStream(filename)
   }
@@ -37,7 +43,7 @@ module.exports = function(dat, opts, cb) {
 
   writer.on('detect', function (detected) {
     var detectInfo = 'Parsing detected format ' + detected.format
-    if(detected.format === 'csv')
+    if (detected.format === 'csv')
       detectInfo += ' with separator "' + detected.separator + '"'
     else if(detected.format === 'json')
       detectInfo += ' in ' + detected.style + ' style'

--- a/test/tests/cli.js
+++ b/test/tests/cli.js
@@ -199,6 +199,43 @@ module.exports.importCSV = function(test, common) {
   })
 }
 
+module.exports.importTSV = function(test, common) {
+  test('CLI dat import tsv', function(t) {
+    common.destroyTmpDats(function() {
+      mkdirp(common.dat1tmp, function(err) {
+        t.notOk(err, 'no err')
+        initDat({cwd: common.dat1tmp, timeout: timeout, rpc: common.rpc}, function(cleanup) {
+          var testTsv = path.join(os.tmpdir(), 'test.tsv')
+          fs.writeFileSync(testTsv, 'a\tb\tc\n1\t2\t3\n4\t5\t6\n7\t8\t9')
+          var cmd = datCmd + ' import "' + testTsv + '" --quiet --results'
+          child.exec(cmd, {timeout: timeout, cwd: common.dat1tmp}, done)
+          
+          function done(err, stdo, stde) {
+            if (process.env.DEBUG) {
+              process.stdout.write(stdo.toString())
+              process.stdout.write(stde.toString())
+            }
+            
+            t.notOk(err, 'no err')
+            t.equals(stde.toString(), '', 'empty stderr')
+            var lines = stdo.toString().split('\n')
+            var rows = []
+            lines.map(function(l) {
+              if (l !== '') rows.push(JSON.parse(l))
+            })
+            t.equal(rows.length, 3)
+            rows.map(function(r) { t.ok(r.key, 'row has key') })
+            common.destroyTmpDats(function() {
+              cleanup()
+              t.end()
+            })
+          }
+        })
+      })
+    })
+  })
+}
+
 module.exports.blobs = function(test, common) {
   test('CLI dat blobs get && dat blobs put', function(t) {
     if (common.rpc) return t.end()
@@ -563,6 +600,7 @@ module.exports.all = function (test, common) {
   module.exports.listenEmptyDir(test, common)
   module.exports.listenPort(test, common)
   module.exports.importCSV(test, common)
+  module.exports.importTSV(test, common)
   module.exports.blobs(test, common)
   module.exports.rows(test, common)
   module.exports.badCommand(test, common)


### PR DESCRIPTION
Per #217, the CLI checks to see if a data file with a `.tsv` file extension is being imported.  If so, sets `opts` as appropriate (`opts.csv = true` and `opts.separator = <TAB>`).

An `importTSV` test was added to `test/tests/cli.js`, modeled on the existing `importCSV` test.
