### PR TITLE
Usage information for each command with --help / -h

### DIFF
--- a/bin/blobs-get.js
+++ b/bin/blobs-get.js
@@ -1,6 +1,10 @@
-module.exports = function(dat, opts, cb) {
+module.exports = blobsGet
+
+blobsGet.usage = 'dat blobs get <rowKey> <blobKey>'
+
+function blobsGet(dat, opts, cb) {
   var args = opts._.slice(2)
-  if (args.length < 2) return cb(new Error('Usage: dat blobs get <rowKey> <blobKey>'))
+  if (args.length < 2) return cb(new Error('Usage: ' + blobsGet.usage))
   var rs = dat.createBlobReadStream(args[0], args[1])
   rs.on('end', cb)
   rs.on('error', cb)

--- a/bin/blobs-put.js
+++ b/bin/blobs-put.js
@@ -4,13 +4,16 @@ var tty = require('tty')
 
 var isTTY = tty.isatty(0)
 
-module.exports = function(dat, opts, cb) {
+module.exports = blobsPut
+
+blobsPut.usage = 'dat blobs put <row> [file-path-to-read] [--name=blob-name-to-use-as-key] [--version=row-version-to-update]'
+
+function blobsPut(dat, opts, cb) {
   var args = opts._.slice(2)
-  var usage = 'Usage: dat blobs put <row> [file-path-to-read] [--name=blob-name-to-use-as-key] [--version=row-version-to-update]'
-  if (args.length === 0) return cb(new Error(usage))
+  if (args.length === 0) return cb(new Error('Usage ' + blobsPut.usage))
   var key = args[0]
   var blob = args[1]
-  if (!opts.name && !blob) return cb(new Error('Must either specify a blob name (--name) to use or a filename. ' + usage))
+  if (!opts.name && !blob) return cb(new Error('Must either specify a blob name (--name) to use or a filename. '))
   var row = { key: key }
   var version = opts.version || opts.v
   

--- a/bin/blobs.js
+++ b/bin/blobs.js
@@ -1,0 +1,22 @@
+module.exports = rows
+
+var usage = 'dat blobs <put|get>'
+
+var subModules = {
+  'put': './blobs-put',
+  'get': './blobs-get',
+}
+
+rows.usage = function (opts) {
+  var modulePath = subModules[opts._[1]]
+  if(!modulePath) return usage
+    return require(modulePath).usage
+}
+  
+function rows(dat, opts, cb) {
+  var modulePath = subModules[opts._[1]]
+  if(!modulePath) return cb(new Error('Usage: ' + usage))
+    require(modulePath)(dat, opts,cb)
+}
+    
+    

--- a/bin/cat.js
+++ b/bin/cat.js
@@ -4,8 +4,16 @@ var eos = require('end-of-stream')
 var through = require('through2')
 var ldj = require('ndjson')
 var pump = require('pump')
+var EOL = require('os').EOL
 
-module.exports = function(dat, opts, cb) {
+module.exports = cat
+
+cat.usage = [
+ 'dat cat',
+ 'stream the most recent of all rows'
+ ].join(EOL)
+
+function cat(dat, opts, cb) {
   if (!opts) opts = {}
   if (!opts.f && !opts.json) opts.json = true
 

--- a/bin/clean.js
+++ b/bin/clean.js
@@ -1,6 +1,11 @@
 var path = require('path')
 var rimraf = require('rimraf')
+var EOL = require('os').EOL
 
-module.exports = function(dat, opts, cb) {
+module.exports = clean
+
+clean.usage = ['dat clean', 'remove .dat folder'].join(EOL)
+
+function clean(dat, opts, cb) {
   rimraf('.dat', cb)
 }

--- a/bin/clone.js
+++ b/bin/clone.js
@@ -1,7 +1,11 @@
 var log = require('../lib/progress-log')
 var EOL = require('os').EOL
 
-module.exports = function(dat, opts, cb) {
+module.exports = clone
+
+clone.usage = ['dat clone <remoteurl>', 'download a dat locally'].join(EOL)
+
+function clone(dat, opts, cb) {
   if (dat.storage && dat.storage.change > 0) return cb(new Error('Cannot clone into existing dat repo'))
   var remote = opts._[1]
   var clone = dat.clone(remote, opts, cb)

--- a/bin/import.js
+++ b/bin/import.js
@@ -9,7 +9,14 @@ var path = require('path')
 
 var isTTY = tty.isatty(0)
 
-module.exports = function(dat, opts, cb) {
+module.exports = importCmd
+
+importCmd.usage = ['dat import [<file>]',
+  'import tabular data into dat', '',
+  'also allows piping, e.g. cat file.json | dat import --json'
+].join(EOL)
+
+function importCmd(dat, opts, cb) {
   var filename = opts._[1]
   var input = null
 

--- a/bin/init.js
+++ b/bin/init.js
@@ -1,7 +1,13 @@
 var path = require('path')
 var read = require('read')
+var EOL = require('os').EOL
 
-module.exports = function(dat, opts, cb) {
+module.exports = init
+
+init.usage = ['dat init', 'initialize dat store'].join(EOL)
+
+
+function init(dat, opts, cb) {
   dat.exists(opts, function(exists) {
     if (exists) return cb(new Error('Skipping dat init because there is already a dat here'))
     prompt(function(err) {

--- a/bin/listen.js
+++ b/bin/listen.js
@@ -1,4 +1,10 @@
-module.exports = function(dat, opts, cb) {
+var EOL = require('os').EOL
+
+module.exports = listen
+
+listen.usage = ['dat listen [--port=<port>]', 'Start a dat server'].join(EOL)
+
+function listen(dat, opts, cb) {
   dat.listen(opts.port, opts, function(err, port) {
     if (err) return cb(err)
     console.log('Listening on port ' + port)

--- a/bin/pull.js
+++ b/bin/pull.js
@@ -1,6 +1,11 @@
 var log = require('../lib/progress-log')
+var EOL = require('os').EOL
 
-module.exports = function(dat, opts, cb) {
+module.exports = pull
+
+pull.usage = ['dat pull <remoteurl>', 'pull data from another dat'].join(EOL)
+
+function pull(dat, opts, cb) {
   var remote = opts._[1]
   var pull = dat.pull(remote, opts, cb)
   if (!opts.quiet) log(pull, 'Pulled', 'Pulling from changes has completed.')

--- a/bin/push.js
+++ b/bin/push.js
@@ -2,7 +2,11 @@ var log = require('../lib/progress-log')
 var EOL = require('os').EOL
 var through = require('through2')
 
-module.exports = function(dat, opts, cb) {
+module.exports = push
+
+push.usage = ['dat push <remoteurl>', 'push data to another dat'].join(EOL)
+
+function push(dat, opts, cb) {
   var remote = opts._[1]
   var push = dat.push(remote, opts, cb)
 

--- a/bin/rows-delete.js
+++ b/bin/rows-delete.js
@@ -1,7 +1,10 @@
-module.exports = function (dat, opts, cb) {
+module.exports = rowsDelete
+
+rowsDelete.usage = 'dat rows delete <rowKey>'
+
+function rowsDelete(dat, opts, cb) {
   var args = opts._.slice(2)
-  if (args.length < 1) return cb(new Error('Usage: dat rows delete <rowKey>'))
-  
+  if(args.length === 0) return cb(new Error('Usage: ' + rowsDelete.usage))
   dat.delete(args[0],function (err, newVersion) {
     if(err) return cb(err)
     console.log('Row with key', args[0], 'marked as deleted.')

--- a/bin/rows-get.js
+++ b/bin/rows-get.js
@@ -1,6 +1,10 @@
-module.exports = function (dat, opts, cb) {
+module.exports = rowsGet
+
+rowsGet.usage = 'dat rows get <rowKey> [<version>]'
+
+function rowsGet(dat, opts, cb) {
   var args = opts._.slice(2)
-  if (args.length < 1) return cb(new Error('Usage: dat rows get <rowKey> [<version>]'))
+  if(args.length === 0) return cb(new Error('Usage: ' + rowsGet.usage))
   var opts = {}
   if(args[1]) opts.version = Number(args[1])
   

--- a/bin/rows-put.js
+++ b/bin/rows-put.js
@@ -1,8 +1,11 @@
 var fs = require('fs')
 var concat = require('concat-stream')
 
-// 'Usage: dat rows put <file-path-to-read> [--key=row-key-to-use]'
-module.exports = function (dat, opts, cb) {
+module.exports = rowsPut
+
+rowsPut.usage = 'dat rows put <file-path-to-read> [--key=row-key-to-use]'
+
+function rowsPut(dat, opts, cb) {
   var args = opts._.slice(2)
   var key = opts.key || opts.k
   var file = args[0]

--- a/bin/rows.js
+++ b/bin/rows.js
@@ -1,0 +1,22 @@
+module.exports = rows
+
+var usage = 'dat rows <put|get|delete>'
+
+var subModules = {
+  'put': './rows-put',
+  'get': './rows-get',
+  'delete': './rows-delete'
+}
+
+rows.usage = function (opts) {
+  var modulePath = subModules[opts._[1]]
+  if(!modulePath) return usage
+  return require(modulePath).usage
+}
+    
+function rows(dat, opts, cb) {
+  var modulePath = subModules[opts._[1]]
+  if(!modulePath) return cb(new Error('Usage: ' + usage))
+  require(modulePath)(dat, opts,cb)
+}
+        

--- a/bin/version.js
+++ b/bin/version.js
@@ -1,4 +1,10 @@
-module.exports = function(dat, opts, cb) {
+var EOL = require('os').EOL
+
+module.exports = version
+
+version.usage = ['dat version', 'show dat version'].join(EOL)
+
+function version(dat, opts, cb) {
   console.log('dat version ' + dat.version)
   process.nextTick(cb)
 }

--- a/cli.js
+++ b/cli.js
@@ -17,10 +17,6 @@ var onerror = function(err) {
   exit(2)
 }
 
-// rules:
-// a 1 part command and a 2 part command can't share the same first part
-// e.g. if 'dat cat' exists you can't add 'dat cat dog'
-
 var bin = {
   "cat": './bin/cat',
   "export": './bin/cat',
@@ -34,11 +30,8 @@ var bin = {
   "clone": './bin/clone',
   "serve": './bin/listen',
   "listen": './bin/listen',
-  "blobs get": "./bin/blobs-get",
-  "blobs put": "./bin/blobs-put",
-  "rows get": "./bin/rows-get",
-  "rows delete": "./bin/rows-delete",
-  "rows put": "./bin/rows-put"
+  "blobs": './bin/blobs',
+  "rows": "./bin/rows"
 }
 
 var argv = minimist(process.argv.slice(2), {boolean: true})
@@ -48,23 +41,40 @@ var second = argv._[1] || ''
 var cmd = first
 if (!bin.hasOwnProperty(first)) cmd = first + ' ' + second
 
-var defaultMessage = "Usage: dat <command> [<args>]" + EOL + EOL + "Enter 'dat help' for help"
-var badMessage = ['Command not found: ' + cmd, '', defaultMessage].join(EOL)
-
 if (!bin.hasOwnProperty(first) && !bin.hasOwnProperty(cmd)) {
-  console.error(first ? badMessage : defaultMessage)
+  if(first) console.error('Command not found: ' + cmd + EOL)
+  console.error("Usage: dat <command> [<args>]" + EOL)
+  if(!first) {
+    console.error('where <command> is one of:')
+    Object.keys(bin).forEach(function (key) {
+      console.error('  ' + key )
+    })
+  }
+  console.error(EOL + "Enter 'dat <command> -h' for usage information")
+  console.error("For an introduction to dat see 'dat help'")
   exit(1)
 }
 
 var dir = (first === 'clone' && (argv._[2] || toFolder(argv._[1]))) || argv.path || '.' // leaky
 var noDat = (first === 'init' || first === 'clone' || first === 'version' || first === 'help')
 
+var cmdModule = require(bin[cmd])
+
+if(argv.h || argv.help) {
+  var usage = cmdModule.usage
+  if(usage) { // if it doesn't export usage just continue
+    if(typeof usage == 'function') usage = usage(argv)
+    console.log('Usage:', usage)
+    exit()
+  }
+}
+
 var dat = Dat(dir, {init: false}, function(err) {
   if (err) return onerror(err)
 
   var execCommand = function(err) {
     if (err) return onerror(err)
-    require(bin[cmd])(dat, argv, function(err) {
+    cmdModule(dat, argv, function(err) {
       if (err) {
         if (cmd === 'init') {
           console.error(err.message)

--- a/test/tests/cli.js
+++ b/test/tests/cli.js
@@ -221,7 +221,7 @@ module.exports.blobs = function(test, common) {
             getFirstOutput(dat.stderr, verify)
         
             function verify(output) {
-              var success = (output.indexOf('Command not found: blobs') > -1)
+              var success = (output.indexOf('Usage: dat blobs') > -1)
               if (!success) console.log(['output:', output])
               t.ok(success, 'output matches')
               kill(dat.pid)
@@ -332,7 +332,7 @@ module.exports.rows = function(test, common) {
             getFirstOutput(dat.stderr, verify)
         
             function verify(output) {
-              var success = (output.indexOf('Command not found: rows') > -1)
+              var success = (output.indexOf('Usage: dat rows') > -1)
               if (!success) console.log(['output:', output])
               t.ok(success, 'output matches')
               kill(dat.pid)


### PR DESCRIPTION
This is a proposal on how to have a consistent `--help` flag for each command. Similar to how `npm` does it, each command is a module that also exports a `usage` string key. This gets automatically printed on `dat <command> --help` (if available)

I also moved all double-commands like `dat blobs put` and `dat blobs get` to be submodules of `dat blobs`. For those cases the blobs.js module exports a function on `.usage` which gets the args as an input and can return the usage string for the appropriate subcommand.

So `dat rows` no longer shows `command not available` put instead prints usage informations instead.

Also the dat command itself shows this now:

```
$ dat
Usage: dat <command> [<args>]

where <command> is one of:
  cat
  export
  import
  init
  help
  version
  pull
  push
  clean
  clone
  serve
  listen
  blobs
  rows

Enter 'dat <command> -h' for usage information
For an introduction to dat see 'dat help'
```
