### PR TITLE
Parse version key as number, fixes csv import with version key

### DIFF
--- a/lib/write-stream.js
+++ b/lib/write-stream.js
@@ -70,7 +70,12 @@ module.exports = function writeStream(dat, opts) {
       return through.obj(function(row, enc, cb) {
         dat.beforePut(row, function(err, row) {
           if (err) return cb(err)
-          cb(null, new KeyStruct(row.version, docUtils.extractPrimaryKey(row, opts), dat.schema.encode(row)))
+          var version = row.version
+          if(typeof version !== 'number') {
+            version = parseInt(version)
+            if(isNaN(version)) delete version
+          }
+          cb(null, new KeyStruct(version, docUtils.extractPrimaryKey(row, opts), dat.schema.encode(row)))
         })
       })
     }

--- a/test/tests/write-streams.js
+++ b/test/tests/write-streams.js
@@ -620,6 +620,24 @@ module.exports.multipleCSVWriteStreamsChangingSchemas = function(test, common) {
   })
 }
 
+module.exports.csvWithVersionKey = function (test, common) {
+  test('csv with version key', function (t) {
+    common.getDat(t, function (dat, done) {
+      var ws = dat.createWriteStream({csv: true, quiet: true})
+      ws.write(bops.from('a,b,version\n1,2,3\n1,2,\n1,2,missing'))
+      ws.end()
+      ws.on('finish', function () {
+        dat.createReadStream().pipe(concat(function (rows) {
+          t.equals(rows[0].version, 3)
+          t.equals(rows[1].version, 1)
+          t.equals(rows[2].version, 1)
+          done()
+        }))
+      })
+    })
+  })
+}
+
 module.exports.keepTotalRowCount = function(test, common) {
   test('keeps row count for streams', function(t) {
     common.getDat(t, function(dat, done) {
@@ -838,6 +856,7 @@ module.exports.all = function (test, common) {
   module.exports.writeStreamCsvNoHeaderRow(test, common)
   module.exports.writeStreamMultipleWithRandomKeys(test, common)
   module.exports.multipleCSVWriteStreamsChangingSchemas(test, common)
+  module.exports.csvWithVersionKey(test, common)
   module.exports.keepTotalRowCount(test, common)
   module.exports.detectInputType(test, common)
 }


### PR DESCRIPTION
Right now if you import a csv with version key into dat, you get `Error: pack(n) must be called with a number`. 

This fixes it by parsing the version key on a createWriteStream as a number. It also ignores non-parseable versions.
