### PR TITLE
Fix failing clone test

### DIFF
--- a/test/tests/cli.js
+++ b/test/tests/cli.js
@@ -610,9 +610,8 @@ module.exports.clone = function(test, common) {
     common.destroyTmpDats(function() {
       mkdirp(common.dat1tmp, function(err) {
         t.notOk(err, 'no err')
-        var dat = spawn(datCliPath, ['clone', 'localhost:9999'], {cwd: path.join(common.dat1tmp, '..'), env: process.env})
+        var dat = spawn(datCliPath, ['clone', 'localhost:9999', '--quiet'], {cwd: path.join(common.dat1tmp, '..'), env: process.env})
         getFirstOutput(dat.stderr, verify)
-        
         function verify(output) {
           t.ok(output.indexOf('ECONNREFUSED') > -1, 'got ECONNREFUSED')
           


### PR DESCRIPTION
The problem was that it was printing the status information first on `dat clone`. I think the output is fine, so I updated the test to use the `--quiet` option.

The output is

```
Elapsed      : 0 s
Pulled       : 0 B       (0 B/s)

Error: connect ECONNREFUSED
``
```
