### PR TITLE
BUG: https will work now

### DIFF
--- a/lib/commands.js
+++ b/lib/commands.js
@@ -4,6 +4,7 @@ var fs = require('fs')
 var path = require('path')
 var EOL = require('os').EOL
 var events = require('events')
+var url = require('url')
 
 var eos = require('end-of-stream')
 var pump = require('pump')
@@ -670,7 +671,8 @@ dat.normalizeURL = function(urlString) {
   // strip trailing /
   if (urlString[urlString.length - 1] === '/') urlString = urlString.slice(0, urlString.length - 1)
 
-  if (!urlString.match(/^http:\/\//)) urlString = 'http://' + urlString
+  var parsedUrl = url.parse(urlString)
+  if (!parsedUrl.protocol) urlString = 'http://' + urlString
 
   return urlString
 }


### PR DESCRIPTION
http:// was getting added to the beginning of https:// urls, causing the
remote to be expanded arbitrarily to http://https:// when the user
entered a remote that was https
