### PR TITLE
fix string path option in destroy method

### DIFF
--- a/lib/commands.js
+++ b/lib/commands.js
@@ -158,7 +158,7 @@ dat.destroy = function(options, cb) {
     options = {}
   }
   var self = this
-  if (typeof options === 'string') options = {path: path}
+  if (typeof options === 'string') options = {path: options}
 
   var paths = self.paths(options.path)
 


### PR DESCRIPTION
This fixes a typo that mistakes path module for options as path string
