### PR TITLE
require protocol-buffers v2.4.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "negotiator": "^0.4.9",
     "peek-stream": "^1.1.1",
     "pretty-bytes": "^0.1.1",
-    "protocol-buffers": "^2.3.3",
+    "protocol-buffers": "^2.4.5",
     "pump": "^0.3.5",
     "pumpify": "^1.3.2",
     "read": "^1.0.5",


### PR DESCRIPTION
v2.4.5 has improved handling of JSON properties that start with special characters like '@' . This can be handy when loading JSON-LD for example, since it has keys like '@id'. More context is over at https://github.com/mafintosh/protocol-buffers/issues/22
