### PR TITLE
use message arrays with new status-logger API

### DIFF
--- a/commands/download.js
+++ b/commands/download.js
@@ -8,7 +8,10 @@ var ui = require('../lib/ui')
 module.exports = function (args) {
   if (args && args.exit) args.upload = false
   var dat = Dat(args)
-  var log = logger(args)
+
+  var messages = []
+  var progressLines = []
+  var log = logger([messages, progressLines], {debug: args.debug, quiet: args.quiet})
 
   var downloadTxt = 'Downloading '
   var finished = false
@@ -16,13 +19,13 @@ module.exports = function (args) {
   dat.stats.rateUp = speedometer()
   dat.stats.rateDown = speedometer()
 
-  log.status('Starting Dat...\n', 0)
-  log.status('Connecting...', 1)
+  progressLines[0] = 'Starting Dat...\n'
+  progressLines[1] = 'Connecting...'
 
   dat.on('error', onerror)
 
   dat.open(function () {
-    log.message('Downloading in ' + dat.dir + '\n')
+    messages.push('Downloading in ' + dat.dir + '\n')
     dat.download(function (err) {
       if (err) onerror(err)
     })
@@ -35,7 +38,7 @@ module.exports = function (args) {
   })
 
   dat.once('key', function (key) {
-    log.message(ui.keyMsg(key))
+    messages.push(ui.keyMsg(key))
     if (args.quiet) console.log(ui.keyMsg(key))
   })
 
@@ -53,7 +56,7 @@ module.exports = function (args) {
     finished = false
     dat.stats.rateDown = speedometer()
     updateStats()
-    log.status('', -1) // remove download finished message
+    progressLines[2] = '' // remove download finished message
   })
   dat.on('file-downloaded', updateStats)
 
@@ -62,16 +65,16 @@ module.exports = function (args) {
     dat.stats.rateDown = 0
     updateStats()
     if (args.exit) {
-      log.status('', 1)
+      progressLines[1] = '' // clear swarm info before exiting
       process.exit(0)
     }
-    log.status('\nDownload Finished. You may exit the process with Ctrl-C.', -1)
+    progressLines[2] = '\nDownload Finished. You may exit the process with Ctrl-C.'
   })
 
   dat.on('swarm-update', printSwarm)
 
   function printSwarm () {
-    log.status(ui.swarmMsg(dat), 1)
+    progressLines[1] = ui.swarmMsg(dat)
   }
 
   function updateStats () {
@@ -83,7 +86,7 @@ module.exports = function (args) {
     }
     msg += ' ' + downloadTxt + chalk.bold(stats.filesTotal) + ' items'
     msg += chalk.dim(' (' + prettyBytes(stats.bytesProgress) + '/' + prettyBytes(stats.bytesTotal) + ')')
-    log.status(msg + '\n', 0)
+    progressLines[0] = msg + '\n'
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "pretty-bytes": "^3.0.0",
     "pump": "^1.0.1",
     "speedometer": "^1.0.0",
-    "status-logger": "^2.0.1"
+    "status-logger": "^3.0.0"
   },
   "bugs": {
     "url": "https://github.com/datproject/dat/issues"


### PR DESCRIPTION
@juliangruber's recent PR got me thinking about how to improve the logger API (which was not very clear before). I updated the [status-logger](https://github.com/joehand/status-logger) API to print arrays of messages and have the user be responsible for updating the arrays.

This PR has two logging lists, `messages` and `progressLines`. `messages` we push and never update.  `progressLines` we update & overwrite. 

Does this API makes more sense on the logger? 

The status-logger update also uses [ansi-diff-stream](https://github.com/mafintosh/ansi-diff-stream) so updates are a bit smoother looking.
