### PR TITLE
Add/webrtc

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ general options
 
   --version, -v         get installed dat version
   --temp                use in-memory database instead of .dat folder
+  --webrtc              connect to webrtc peers via electron-webrtc
   --doctor              run dat doctor
   --quiet, -q           output only dat-link, no progress information
   --debug               show debugging output
@@ -187,6 +188,10 @@ When you run a command, Dat creates a hidden folder, `.dat`, in the directory sp
 #### Temporary Database
 
 Use the `--temp` option to keep the metadata in memory instead of the `.dat` folder.
+
+### Sharing or Download files with [dat.land](http://dat.land)
+
+You can use the `--webrtc` option to share files to dat.land. You'll need to install `electron-webrtc` in order for this to work.
 
 ## Troubleshooting
 

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -30,7 +30,7 @@ if (args.webrtc) {
   try {
     args.webrtc = require('electron-webrtc')({headless: true})
   } catch (e) {
-    onerror('npm install electron-webrtc for webrtc support (use -g option if that is how you installed dat)')
+    onerror('npm install -g electron-webrtc for webrtc support')
   }
 }
 

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -28,7 +28,7 @@ if (args.version) {
 
 if (args.webrtc) {
   try {
-    args.webrtc = require('electron-webrtc')({headless: false})
+    args.webrtc = require('electron-webrtc')({headless: true})
   } catch (e) {
     onerror('npm install electron-webrtc for webrtc support (use -g option if that is how you installed dat)')
   }

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -5,7 +5,7 @@ var mkdirp = require('mkdirp')
 
 var args = require('minimist')(process.argv.splice(2), {
   alias: {p: 'port', q: 'quiet', v: 'version'},
-  boolean: ['snapshot', 'exit', 'list', 'quiet', 'version', 'utp', 'temp'],
+  boolean: ['snapshot', 'exit', 'list', 'quiet', 'version', 'utp', 'temp', 'webrtc'],
   default: {
     logspeed: 200
   }
@@ -24,6 +24,14 @@ if (args.version) {
   var pkg = require('../package.json')
   console.log(pkg.version)
   process.exit(0)
+}
+
+if (args.webrtc) {
+  try {
+    args.webrtc = require('electron-webrtc')({headless: false})
+  } catch (e) {
+    onerror('npm install electron-webrtc for webrtc support (use -g option if that is how you installed dat)')
+  }
 }
 
 var isShare = false

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 *Note: unreleased changes are added here.*
+### Added
+* `--webrtc` option. Uses electron-webrtc to run via webrtc.
 
 ## 11.2.0 - 2016-09-14
 ### Added

--- a/tests/misc.js
+++ b/tests/misc.js
@@ -1,0 +1,24 @@
+var path = require('path')
+var test = require('tape')
+var spawn = require('./helpers/spawn.js')
+
+var dat = path.resolve(path.join(__dirname, '..', 'bin', 'cli.js'))
+var fixtures = path.join(__dirname, 'fixtures')
+
+test('webrtc option fails if electron-webrtc not installed', function (t) {
+  // cmd: dat tests/fixtures --webrtc
+  try {
+    require('electron-webrtc')
+    t.skip('electron-webrtc installed, skipping fail test. Uninstall to test.')
+  } catch (e) {
+    var st = spawn(t, dat + ' ' + fixtures + ' --webrtc')
+    st.fails('errors')
+    st.end()
+  }
+})
+
+test('webrtc option works with electron-webrtc installed', function (t) {
+  // cmd: dat tests/fixtures --webrtc
+  t.skip('TODO: somehow test this')
+  t.end()
+})

--- a/usage/root.txt
+++ b/usage/root.txt
@@ -16,6 +16,7 @@ general options
 
   --version, -v         get installed dat version
   --temp                use in-memory database instead of .dat folder
+  --webrtc              connect to webrtc peers via electron-webrtc
   --doctor              run dat doctor
   --quiet, -q           output only dat-link, no progress information
   --debug               show debugging output


### PR DESCRIPTION
Adds `--webrtc` option. 

* Requires user install electron-webrtc on their own. It'll error if they do not have it installed.

## Question

* The `headless: true` option could cause errors if xvfb isn't installed. I (still) haven't figured out how to get this to work on my mac. Should be make `headless: false` an option somehow? It could be another boolean arg: `--webrtc-headless` and `--no-webrtc-headless`. But if there is another way, I'd rather avoid more arguments if possible. This is not a blocker and can be done later.