### PR TITLE
give good output when user uses incorrect command params

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -2,7 +2,7 @@
 
 var fs = require('fs')
 var mkdirp = require('mkdirp')
-var usage = require('../usage')('root.txt')
+var usage = require('../usage')
 
 var args = require('minimist')(process.argv.splice(2), {
   alias: {p: 'port', q: 'quiet', v: 'version'},
@@ -53,7 +53,7 @@ function run () {
   else if (isShare) require('../commands/share')(args)
   else if (args.list && isDownload) require('../commands/list')(args)
   else if (isDownload) require('../commands/download')(args)
-  else usage()
+  else usage('root.txt')
 }
 
 function getCommand () {
@@ -66,7 +66,7 @@ function getCommand () {
   if (isShare) run()
   else if (args.dir && isDownload && !isDirectory(args.dir, true)) mkdirp(args.dir, run)
   else if (args.dir && isDownload) run()
-  else if (!args.dir) usage() // TODO: don't require for download
+  else if (!args.dir) usage('root.txt') // TODO: don't require for download
   else onerror('Invalid Command') // Should never get here...
 }
 

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -2,6 +2,7 @@
 
 var fs = require('fs')
 var mkdirp = require('mkdirp')
+var usage = require('../usage')('root.txt')
 
 var args = require('minimist')(process.argv.splice(2), {
   alias: {p: 'port', q: 'quiet', v: 'version'},
@@ -52,7 +53,7 @@ function run () {
   else if (isShare) require('../commands/share')(args)
   else if (args.list && isDownload) require('../commands/list')(args)
   else if (isDownload) require('../commands/download')(args)
-  else require('../usage')('root.txt')
+  else usage()
 }
 
 function getCommand () {
@@ -65,7 +66,7 @@ function getCommand () {
   if (isShare) run()
   else if (args.dir && isDownload && !isDirectory(args.dir, true)) mkdirp(args.dir, run)
   else if (args.dir && isDownload) run()
-  else if (!args.dir) onerror('Directory required') // TODO: don't require for download
+  else if (!args.dir) usage() // TODO: don't require for download
   else onerror('Invalid Command') // Should never get here...
 }
 

--- a/tests/download.js
+++ b/tests/download.js
@@ -70,7 +70,7 @@ test('errors on new download without directory', function (t) {
   rimraf.sync(path.join(process.cwd(), '.dat')) // in case we have a .dat folder here
   var st = spawn(t, dat + ' 5hz25io80t0m1ttr332awpslmlfn1mc5bf1z8lvhh34a9r1ob3')
   st.stderr.match(function (output) {
-    var gotError = output.indexOf('Directory required') > -1
+    var gotError = output.indexOf('dat <directory>') > -1
     t.ok(gotError, 'got error')
     if (gotError) return true
   })

--- a/usage/root.txt
+++ b/usage/root.txt
@@ -3,14 +3,12 @@ dat <directory>
   share directory and create a dat-link
 
   --snapshot            create a snapshot of directory
-  --port, -p            set a specific inbound tcp port
 
 dat <dat-link> <directory>
 
   download a dat-link into directory
 
   --exit                exit process after download finishes
-  --port, -p            set a specific inbound tcp port
 
 general options
 
@@ -21,3 +19,4 @@ general options
   --quiet, -q           output only dat-link, no progress information
   --debug               show debugging output
   --ignore-hidden       ignore hidden files (true by default)
+  --port, -p            set a specific inbound tcp port


### PR DESCRIPTION
When a user didn't input a second argument for 'directory', it would before just say 'Directory required' which was confusing for users during user testing.

This also moves the 'port' option to 'general options' because it affects the dat process when its connected to a swarm, and is the same across both commands.
