### PR TITLE
Sync on sharing a directory that has a dat in it already

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -3,6 +3,7 @@
 var fs = require('fs')
 var mkdirp = require('mkdirp')
 var usage = require('../usage')
+var Dat = require('dat-js')
 
 var args = require('minimist')(process.argv.splice(2), {
   alias: {p: 'port', q: 'quiet', v: 'version'},
@@ -49,10 +50,12 @@ if (args.doctor || !args._[0]) run()
 else getCommand()
 
 function run () {
-  if (args.doctor) require('./doctor')(args)
-  else if (isShare) require('../commands/share')(args)
-  else if (args.list && isDownload) require('../commands/list')(args)
-  else if (isDownload) require('../commands/download')(args)
+  if (args.temp) args.db = require('memdb')()
+  var dat = Dat(args)
+  if (args.doctor) require('./doctor')(dat, args)
+  else if (isShare) require('../commands/share')(dat, args)
+  else if (args.list && isDownload) require('../commands/list')(dat, args)
+  else if (isDownload) require('../commands/download')(dat, args)
   else usage('root.txt')
 }
 

--- a/commands/download.js
+++ b/commands/download.js
@@ -1,14 +1,10 @@
 var chalk = require('chalk')
 var prettyBytes = require('pretty-bytes')
-var Dat = require('dat-js')
 var logger = require('status-logger')
 var speedometer = require('speedometer')
 var ui = require('../lib/ui')
 
-module.exports = function (args) {
-  if (args && args.exit) args.upload = false
-  if (args.temp) args.db = require('memdb')()
-  var dat = Dat(args)
+module.exports = function (dat, args) {
   var log = logger(args)
 
   var downloadTxt = 'Downloading '

--- a/commands/share.js
+++ b/commands/share.js
@@ -1,15 +1,12 @@
 var chalk = require('chalk')
+var download = require('./download')
 var prettyBytes = require('pretty-bytes')
-var Dat = require('dat-js')
 var logger = require('status-logger')
 var speedometer = require('speedometer')
 var ui = require('../lib/ui')
 
-module.exports = function (args) {
-  if (args.temp) args.db = require('memdb')()
-  var dat = Dat(args)
+module.exports = function (dat, args) {
   var log = logger(args)
-
   var addText = 'Adding '
   var updated = false
   var initFileCount = 0
@@ -23,6 +20,7 @@ module.exports = function (args) {
   dat.on('error', onerror)
 
   dat.open(function () {
+    if (dat.archive.key && !dat.archive.owner) return download(dat, args)
     log.message('Sharing ' + dat.dir + '\n')
     dat.share(function (err) {
       if (err) onerror(err)

--- a/tests/share.js
+++ b/tests/share.js
@@ -166,7 +166,7 @@ test('share with temp arg', function (t) {
   st.end()
 })
 
-test.only('sharing existing directory begins sync', function (t) {
+test('sharing existing directory begins sync', function (t) {
   // cmd: dat <link> .  then dat .
   var tmpdir = newTestFolder()
   var link = null


### PR DESCRIPTION
It used to give some output that told the user to run a manual command to sync. Now it'll just sync for them.

fixes #535 