### PR TITLE
fix usage print out on empty stdarg. fixes #557

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 tmp
 .idea
 data
+tests/fixtures/.dat

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -53,10 +53,9 @@ function run () {
   if (args.temp) args.db = require('memdb')()
   if (args.doctor) require('./doctor')(args)
   else {
-    var dat = Dat(args)
-    if (isShare) require('../commands/share')(dat, args)
-    else if (args.list && isDownload) require('../commands/list')(dat, args)
-    else if (isDownload) require('../commands/download')(dat, args)
+    if (isShare) require('../commands/share')(Dat(args), args)
+    else if (args.list && isDownload) require('../commands/list')(Dat(args), args)
+    else if (isDownload) require('../commands/download')(Dat(args), args)
     else usage('root.txt')
   }
 }

--- a/tests/misc.js
+++ b/tests/misc.js
@@ -1,9 +1,11 @@
 var path = require('path')
 var test = require('tape')
 var spawn = require('./helpers/spawn.js')
+var fs = require('fs')
 
 var dat = path.resolve(path.join(__dirname, '..', 'bin', 'cli.js'))
 var fixtures = path.join(__dirname, 'fixtures')
+var usage = fs.readFileSync(path.join(__dirname, '..', 'usage', 'root.txt'), 'utf8')
 
 test('webrtc option fails if electron-webrtc not installed', function (t) {
   // cmd: dat tests/fixtures --webrtc
@@ -41,6 +43,15 @@ test('doctor option works ', function (t) {
       t.end()
     })
   }
+})
+
+test('prints usage', function (t) {
+  // cmd: dat
+  var d = spawn(t, dat)
+  d.stderr.match(function (stderr) {
+    return stderr === usage + '\n'
+  })
+  d.end()
 })
 
 test('webrtc option works with electron-webrtc installed', function (t) {


### PR DESCRIPTION
lazily instantiate the dat-js instance so it doesn't throw when .dir isn't set.