### PR TITLE
Do not watch files by default & Simplify sharing UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,19 +81,20 @@ Running `dat` in the console, with no arguments, will show you the usage guide. 
 ```
 dat <directory>
 
-  share directory and create a dat-link
+  Share the given directory and create a link which then can be used to
+  download the data. The process will stay open and watch for filesystem changes.
 
+  --watchFiles          watch files for changes (beta: still in development)
   --snapshot            create a snapshot of directory
-  --port, -p            set a specific inbound tcp port
 
-dat <dat-link> <directory>
+dat <link> <directory>
 
-  download a dat-link into directory
+  Download a dat-link into directory. Continues to listen for changes and
+  download them as they are added by the remote peer.
 
   --exit                exit process after download finishes
-  --port, -p            set a specific inbound tcp port
 
-general options
+General options
 
   --version, -v         get installed dat version
   --temp                use in-memory database instead of .dat folder
@@ -102,6 +103,7 @@ general options
   --quiet, -q           output only dat-link, no progress information
   --debug               show debugging output
   --ignore-hidden       ignore hidden files (true by default)
+  --port, -p            set a specific inbound tcp port
 ```
 
 ### Sharing Files

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -7,12 +7,13 @@ var Dat = require('dat-js')
 
 var args = require('minimist')(process.argv.splice(2), {
   alias: {p: 'port', q: 'quiet', v: 'version'},
-  boolean: ['snapshot', 'exit', 'list', 'quiet', 'version', 'utp', 'temp', 'webrtc', 'ignore-hidden'],
+  boolean: ['watchFiles', 'snapshot', 'exit', 'list', 'quiet', 'version', 'utp', 'temp', 'webrtc', 'ignore-hidden'],
   string: ['signalhub'],
   default: {
     logspeed: 200,
     'ignore-hidden': true,
-    utp: true
+    utp: true,
+    watchFiles: false
   }
 })
 

--- a/commands/share.js
+++ b/commands/share.js
@@ -8,8 +8,7 @@ var ui = require('../lib/ui')
 module.exports = function (dat, args) {
   var log = logger(args)
   var addText = 'Adding '
-  var updated = false
-  var initFileCount = 0
+  var finalized = false
 
   dat.stats.rateUp = speedometer()
 
@@ -59,14 +58,12 @@ module.exports = function (dat, args) {
   })
 
   dat.once('archive-finalized', function () {
-    addText = 'Added '
-    initFileCount = dat.stats.filesTotal
+    addText = 'Sharing '
+    finalized = true
     updateStats()
   })
 
   dat.on('archive-updated', function () {
-    addText = 'Updating '
-    updated = true
     updateStats()
   })
 
@@ -80,17 +77,12 @@ module.exports = function (dat, args) {
     var stats = dat.stats
     var files = stats.filesTotal
     var bytesTotal = stats.bytesTotal
-    var bytesProgress = stats.bytesProgress
 
-    if (dat.live && updated) {
-      if (stats.filesTotal === stats.filesProgress) addText = 'Updated '
-      files = files - initFileCount
-      bytesTotal = stats.bytesTotal
-    }
-
-    var msg = ui.progress(bytesProgress / bytesTotal)
-    msg += ' ' + addText + chalk.bold(files) + ' items'
-    msg += chalk.dim(' (' + prettyBytes(bytesProgress) + '/' + prettyBytes(bytesTotal) + ')')
+    var msg = ui.progress(stats.bytesProgress / bytesTotal)
+    msg += ' ' + addText
+    if (finalized) msg += chalk.bold(files) + ' '
+    msg += 'items'
+    msg += chalk.dim(' (' + prettyBytes(bytesTotal) + ')')
     log.status(msg + '\n', 0)
   }
 }

--- a/lib/ui.js
+++ b/lib/ui.js
@@ -27,7 +27,7 @@ module.exports.swarmMsg = function (dat) {
   else msg = 'Waiting for connections. '
   if (dat.stats.rateDown && dat.stats.rateDown()) msg += 'Downloading ' + prettyBytes(dat.stats.rateDown()) + '/s. '
   if (dat.stats.rateUp && dat.stats.rateUp()) msg += 'Uploading ' + prettyBytes(dat.stats.rateUp()) + '/s. '
-  if (dat.archive && dat.archive && dat.archive.live && dat.archive.owner) msg += 'Watching for updates...'
+  if (dat.options.watchFiles && dat.archive && dat.archive.live && dat.archive.owner) msg += 'Watching for updates...'
   return msg
 }
 

--- a/tests/download.js
+++ b/tests/download.js
@@ -15,7 +15,7 @@ try { fs.unlinkSync(path.join(__dirname, 'fixtures', '.DS_Store')) } catch (e) {
 
 test('starts looking for peers with correct hash', function (t) {
   // cmd: dat <link> downloadDir
-  var st = spawn(t, dat + ' 5hz25io80t0m1ttr332awpslmlfn1mc5bf1z8lvhh34a9r1ob3 ' + downloadDir)
+  var st = spawn(t, dat + ' 5f6f2ff876519b3f999e21f18f4dc5eb91570cebbcda7725009bdfbe9fdd310f ' + downloadDir)
   st.stdout.match(function (output) {
     var downloading = output.indexOf('Waiting for connections') > -1
     if (!downloading) return false
@@ -28,7 +28,7 @@ test('starts looking for peers with correct hash', function (t) {
 
 test('accepts dat-desktop links', function (t) {
   // cmd: dat dat://<link> downloadDir
-  var st = spawn(t, dat + ' dat://ki0dg8b5ukc7oy5gcdhx4nr27ayncu4gdart3y1zf1b8p9sk48 ' + downloadDir)
+  var st = spawn(t, dat + ' dat://5f6f2ff876519b3f999e21f18f4dc5eb91570cebbcda7725009bdfbe9fdd310f ' + downloadDir)
   st.stdout.match(function (output) {
     var downloading = output.indexOf('Waiting for connections') > -1
     if (!downloading) return false
@@ -40,7 +40,7 @@ test('accepts dat-desktop links', function (t) {
 })
 
 test('accepts https://dat.land links', function (t) {
-  var st = spawn(t, dat + ' https://dat.land/ki0dg8b5ukc7oy5gcdhx4nr27ayncu4gdart3y1zf1b8p9sk48 ' + downloadDir)
+  var st = spawn(t, dat + ' https://dat.land/5f6f2ff876519b3f999e21f18f4dc5eb91570cebbcda7725009bdfbe9fdd310f ' + downloadDir)
   st.stdout.match(function (output) {
     var downloading = output.indexOf('Waiting for connections') > -1
     if (!downloading) return false
@@ -52,7 +52,7 @@ test('accepts https://dat.land links', function (t) {
 })
 
 test('accepts dat.land links', function (t) {
-  var st = spawn(t, dat + ' dat.land/ki0dg8b5ukc7oy5gcdhx4nr27ayncu4gdart3y1zf1b8p9sk48 ' + downloadDir)
+  var st = spawn(t, dat + ' dat.land/5f6f2ff876519b3f999e21f18f4dc5eb91570cebbcda7725009bdfbe9fdd310f ' + downloadDir)
   st.stdout.match(function (output) {
     var downloading = output.indexOf('Waiting for connections') > -1
     if (!downloading) return false
@@ -78,7 +78,7 @@ test('errors with invalid hash', function (t) {
 test('makes directory if does not exist', function (t) {
   // cmd: dat pizza downloadDir
   rimraf.sync(path.join(downloadDir))
-  var st = spawn(t, dat + ' 5hz25io80t0m1ttr332awpslmlfn1mc5bf1z8lvhh34a9r1ob3 ' + downloadDir)
+  var st = spawn(t, dat + ' 5f6f2ff876519b3f999e21f18f4dc5eb91570cebbcda7725009bdfbe9fdd310f ' + downloadDir)
   st.stdout.match(function (output) {
     var downloading = output.indexOf('Waiting for connections') > -1
     if (!downloading) return false
@@ -92,7 +92,7 @@ test('makes directory if does not exist', function (t) {
 test('errors on new download without directory', function (t) {
   // cmd: dat <link>
   rimraf.sync(path.join(process.cwd(), '.dat')) // in case we have a .dat folder here
-  var st = spawn(t, dat + ' 5hz25io80t0m1ttr332awpslmlfn1mc5bf1z8lvhh34a9r1ob3')
+  var st = spawn(t, dat + ' 5f6f2ff876519b3f999e21f18f4dc5eb91570cebbcda7725009bdfbe9fdd310f')
   st.stderr.match(function (output) {
     var gotError = output.indexOf('dat <directory>') > -1
     t.ok(gotError, 'got error')
@@ -172,7 +172,7 @@ test('download twice to same dir errors', function (t) {
 
   function spawnDownloaderTwo () {
     // cmd: dat <link> .
-    var downloaderTwo = spawn(t, dat + ' 5hz25io80t0m1ttr332awpslmlfn1mc5bf1z8lvhh34a9r1ob3 ' + tmpdir, {end: false})
+    var downloaderTwo = spawn(t, dat + ' 5f6f2ff876519b3f999e21f18f4dc5eb91570cebbcda7725009bdfbe9fdd310f ' + tmpdir, {end: false})
     downloaderTwo.stderr.match(function (output) {
       var contains = output.indexOf('Another Dat was already downloaded here') > -1
       if (!contains || !share) return false

--- a/tests/share.js
+++ b/tests/share.js
@@ -100,9 +100,9 @@ test('share prints shared directory', function (t) {
 
 test('prints file information (live)', function (t) {
   // cmd: dat tests/fixtures
-  var st = spawn(t, dat + ' ' + fixtures)
+  var st = spawn(t, dat + ' ' + fixtures + ' --watchFiles')
   st.stdout.match(function (output) {
-    var finished = output.match('Added')
+    var finished = output.match('items')
     if (!finished) return false
 
     t.ok(output.match(/2 items/), 'File count correct')
@@ -119,7 +119,7 @@ test('prints file information (snapshot)', function (t) {
   // cmd: dat tests/fixtures --snapshot
   var st = spawn(t, dat + ' ' + fixtures + ' --snapshot')
   st.stdout.match(function (output) {
-    var finished = output.match('Added')
+    var finished = output.match('items')
     if (!finished) return false
 
     t.ok(output.match(/2 items/), 'File count correct')

--- a/usage/root.txt
+++ b/usage/root.txt
@@ -3,6 +3,7 @@ dat <directory>
   Share the given directory and create a link which then can be used to
   download the data. The process will stay open and watch for filesystem changes.
 
+  --watchFiles          watch files for changes (beta: still in development)
   --snapshot            create a snapshot of directory
 
 dat <link> <directory>


### PR DESCRIPTION
* Adds `--watchFiles` option as default false.
* Removes some progress UI elements that were confusing. Only shows total sizes now, which will always reflect the current folder state, not progress.
* Update tests.