### PR TITLE
Improve download stats

### DIFF
--- a/commands/download.js
+++ b/commands/download.js
@@ -73,13 +73,12 @@ module.exports = function (dat, args) {
 
   function updateStats () {
     var stats = dat.stats
-    var msg = ui.progress(stats.bytesProgress / stats.bytesTotal)
-    if (finished || stats.filesProgress >= stats.filesTotal) {
+    var msg = ui.progress(stats.blocksProgress / stats.blocksTotal)
+    if (finished || stats.blocksProgress >= stats.blocksTotal) {
       downloadTxt = 'Downloaded '
-      msg = ui.progress(1) // hack to show completed with existing files
     }
     msg += ' ' + downloadTxt + chalk.bold(stats.filesTotal) + ' items'
-    msg += chalk.dim(' (' + prettyBytes(stats.bytesProgress) + '/' + prettyBytes(stats.bytesTotal) + ')')
+    msg += chalk.dim(' (' + prettyBytes(stats.bytesTotal) + ')')
     log.status(msg + '\n', 0)
   }
 }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "license": "BSD-3-Clause",
   "dependencies": {
     "chalk": "^1.1.1",
-    "dat-js": "^3.6.0",
+    "dat-js": "^3.7.0",
     "datland-swarm-defaults": "^1.0.2",
     "discovery-swarm": "^4.0.2",
     "dns-discovery": "^5.3.4",


### PR DESCRIPTION
- Uses block count for progress (with the new hyperdrive functions that count pre-downloaded blocks)
- Improves file count by checking duplicates
- Removes byte download progress which was really bad before because of pre-downloaded bytes.

Depends on new [dat-js release](https://github.com/joehand/dat-js/pull/27), which is now released!
