### PR TITLE
Bug fixes and dat-js upgrade

### DIFF
--- a/commands/download.js
+++ b/commands/download.js
@@ -81,7 +81,8 @@ module.exports = function (dat, args) {
     if (finished || stats.blocksProgress >= stats.blocksTotal) {
       downloadTxt = 'Downloaded '
     }
-    msg += ' ' + downloadTxt + chalk.bold(stats.filesTotal) + ' items'
+    msg += ' ' + downloadTxt + chalk.bold(stats.filesTotal)
+    msg += (stats.filesTotal === 1) ? ' file' : ' files'
     msg += chalk.dim(' (' + prettyBytes(stats.bytesTotal) + ')')
     progress[0] = msg + '\n'
   }

--- a/commands/download.js
+++ b/commands/download.js
@@ -21,7 +21,8 @@ module.exports = function (dat, args) {
 
   dat.on('error', onerror)
 
-  dat.open(function () {
+  dat.open(function (err) {
+    if (err) return onerror(err)
     messages.push('Downloading in ' + dat.dir + '\n')
     dat.download(function (err) {
       if (err) onerror(err)

--- a/commands/share.js
+++ b/commands/share.js
@@ -87,8 +87,8 @@ module.exports = function (dat, args) {
 
     var msg = ui.progress(stats.bytesProgress / bytesTotal)
     msg += ' ' + addText
-    if (finalized) msg += chalk.bold(files)
-    msg += (files === 1) ? ' file' : ' files'
+    if (finalized) msg += chalk.bold(files) + ' '
+    msg += (files === 1) ? 'file' : 'files'
     msg += chalk.dim(' (' + prettyBytes(bytesTotal) + ')')
     progress[0] = msg + '\n'
   }

--- a/commands/share.js
+++ b/commands/share.js
@@ -87,8 +87,8 @@ module.exports = function (dat, args) {
 
     var msg = ui.progress(stats.bytesProgress / bytesTotal)
     msg += ' ' + addText
-    if (finalized) msg += chalk.bold(files) + ' '
-    msg += 'items'
+    if (finalized) msg += chalk.bold(files)
+    msg += (files === 1) ? ' file' : ' files'
     msg += chalk.dim(' (' + prettyBytes(bytesTotal) + ')')
     progress[0] = msg + '\n'
   }

--- a/commands/share.js
+++ b/commands/share.js
@@ -22,7 +22,8 @@ module.exports = function (dat, args) {
 
   dat.on('error', onerror)
 
-  dat.open(function () {
+  dat.open(function (err) {
+    if (err) return onerror(err)
     dat.archive.open(function () {
       if (dat.archive.key && !dat.archive.owner) return download(dat, args)
       messages.push('Sharing ' + dat.dir + '\n')

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "license": "BSD-3-Clause",
   "dependencies": {
     "chalk": "^1.1.1",
-    "dat-js": "^3.8.0",
+    "dat-js": "^3.8.2",
     "datland-swarm-defaults": "^1.0.2",
     "discovery-swarm": "^4.0.2",
     "dns-discovery": "^5.3.4",

--- a/tests/download.js
+++ b/tests/download.js
@@ -207,7 +207,7 @@ test('download transfers files', function (t) {
       var contains = output.indexOf('Download Finished') > -1
       if (!contains || !share) return false
 
-      var hasFiles = output.indexOf('2 items') > -1
+      var hasFiles = output.indexOf('2 files') > -1
       t.ok(hasFiles, 'file number is 2')
 
       var hasSize = output.indexOf('1.44 kB') > -1

--- a/tests/share.js
+++ b/tests/share.js
@@ -102,10 +102,10 @@ test('prints file information (live)', function (t) {
   // cmd: dat tests/fixtures
   var st = spawn(t, dat + ' ' + fixtures + ' --watchFiles')
   st.stdout.match(function (output) {
-    var finished = output.match(/2 items/)
+    var finished = output.match(/2 files/)
     if (!finished) return false
 
-    t.ok(output.match(/2 items/), 'File count correct')
+    t.ok(output.match(/2 files/), 'File count correct')
     t.ok(output.match(/1\.\d{1,2} kB/), 'File size correct')
 
     st.kill()
@@ -119,10 +119,10 @@ test('prints file information (snapshot)', function (t) {
   // cmd: dat tests/fixtures --snapshot
   var st = spawn(t, dat + ' ' + fixtures + ' --snapshot')
   st.stdout.match(function (output) {
-    var finished = output.match(/2 items/)
+    var finished = output.match(/2 files/)
     if (!finished) return false
 
-    t.ok(output.match(/2 items/), 'File count correct')
+    t.ok(output.match(/2 files/), 'File count correct')
     t.ok(output.match(/1\.\d{1,2} kB/), 'File size correct')
 
     st.kill()


### PR DESCRIPTION
Fixes progress bar bug #566 and (I think) #565. 

Bug #565 may have been caused by an error not being handled on open. I was seeing the dat process from test of that bug use lots of CPU and had to kill it.

Also changed *items* to *files* because it's more human friendly. And made it singular if there is one file.