### PR TITLE
use graceful-fs in place of fs to fix emfile errors

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
 
-var fs = require('fs')
+var realFs = require('fs')
+var gracefulFs = require('graceful-fs')
+gracefulFs.gracefulify(realFs)
 var mkdirp = require('mkdirp')
 var usage = require('../usage')
 var Dat = require('dat-js')
@@ -87,7 +89,7 @@ function isDatLink (val, quiet) {
 
 function isDirectory (val, quiet) {
   try {
-    return fs.statSync(val).isDirectory() // TODO: support sharing single files
+    return gracefulFs.statSync(val).isDirectory() // TODO: support sharing single files
   } catch (err) {
     if (quiet) return false
     onerror('Directory does not exist')

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "datland-swarm-defaults": "^1.0.2",
     "discovery-swarm": "^4.0.2",
     "dns-discovery": "^5.3.4",
+    "graceful-fs": "^4.1.10",
     "memdb": "^1.3.1",
     "minimist": "^1.2.0",
     "mkdirp": "^0.5.1",


### PR DESCRIPTION
This aims to fix #524 with EMFILE errors if ulimit is set to below 2048.

In chokidar, they use `fs` instead of `graceful-fs`. There are issues discussing this and the maintainers still use regular `fs` despite many folks asking them to use `graceful-fs` instead to avoid EMFILE errors.

The case for keeping `fs` instead of `graceful-fs` in `chokidar` is this:

''I don't think it will make sense to switch all of chokidar to graceful-fs because it creates a risk of locking up the program in certain watch modes that hold open too many file descriptors, as described above. In this case it seems better to let the EMFILE happen, resulting in the user educating themselves about ulimit, etc. I considered sniffing for it and printing a console.warn or something like that to tell end-users about the ulimit thing, but I don't think the maintainers of the dependents of chokidar would appreciate it polluting the stderr of their apps.''

However, we won't have that problem, because we are closing file descriptors as we go. See https://github.com/paulmillr/chokidar/issues/141#issuecomment-52683296:  'graceful-fs will be very bad if you are opening and keeping open a lot of file descriptors'

I feel confident using graceful-fs and then closing #524 

