### PR TITLE
use compareFileContents option on importer

### DIFF
--- a/lib/share.js
+++ b/lib/share.js
@@ -76,9 +76,10 @@ module.exports = function sync (type, opts, dat) {
       progressOutput[2] = 'Importing files...'
 
       importStatus = dat.importFiles({
-        watch: opts.watch, // TODO: allow live: true. opts.live is used by archive.live though =(
+        watch: opts.watch,
         resume: true,
-        ignoreHidden: opts.ignoreHidden
+        ignoreHidden: opts.ignoreHidden,
+        compareFileContent: true
       }, function (err) {
         if (err) return exit(err)
         debug('Import finished')

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "dat-encoding": "^4.0.1",
     "dat-node": "^1.3.3",
     "debug": "^2.4.5",
+    "hyperdrive-import-files": "^2.9.0",
     "memdb": "^1.3.1",
     "mkdirp": "^0.5.1",
     "nets": "^3.2.0",


### PR DESCRIPTION
This will avoid importing duplicates. Also getting some weird bugs where a clone/pull will trigger a file watch event, this avoids those.