### PR TITLE
add two decimals to content %

### DIFF
--- a/lib/download.js
+++ b/lib/download.js
@@ -110,7 +110,7 @@ module.exports = function (type, opts, dat) {
     var metaBlocksProgress = archive.metadata.blocks - archive.metadata.blocksRemaining()
     var metaProgress = Math.round(metaBlocksProgress * 100 / archive.metadata.blocks)
     var contentBlocksProgress = archive.content.blocks - archive.content.blocksRemaining()
-    var contentProgress = archive.content.blocks === 0 ? 0 : Math.round(contentBlocksProgress * 100 / archive.content.blocks)
+    var contentProgress = archive.content.blocks === 0 ? 0 : (contentBlocksProgress * 100 / archive.content.blocks).toFixed(2)
     // TODO: fix hyperdrive-stats bug where blocksProgress > blocksTotal
     // var contentProgress = st.blocksTotal === 0 ? 0 : Math.round(st.blocksProgress * 100 / st.blocksTotal)
     progressOutput[2] = 'Metadata: ' + bar(metaProgress) + ' ' + metaProgress + '%'


### PR DESCRIPTION
Adds a few decimals to content progress bar. Was confusing with 0 showing while progress was happening.