### PR TITLE
Fix content progress for archives with history

### DIFF
--- a/lib/download.js
+++ b/lib/download.js
@@ -109,8 +109,9 @@ module.exports = function (type, opts, dat) {
 
     var metaBlocksProgress = archive.metadata.blocks - archive.metadata.blocksRemaining()
     var metaProgress = Math.round(metaBlocksProgress * 100 / archive.metadata.blocks)
-    var contentBlocksProgress = archive.content.blocks - archive.content.blocksRemaining()
-    var contentProgress = archive.content.blocks === 0 ? 0 : (contentBlocksProgress * 100 / archive.content.blocks).toFixed(2)
+    var contentBlocksProgress = archive.content.blocks - archive.content.blocksRemaining() // TODO: for archives with history st.blocksProgress may be off?
+    var contentProgress = st.blocksTotal === 0 ? 0 : (contentBlocksProgress * 100 / st.blocksTotal).toFixed(2)
+    if (contentProgress >= 100) contentProgress = 100 // In case + remove decimal from 100.00
     // TODO: fix hyperdrive-stats bug where blocksProgress > blocksTotal
     // var contentProgress = st.blocksTotal === 0 ? 0 : Math.round(st.blocksProgress * 100 / st.blocksTotal)
     progressOutput[2] = 'Metadata: ' + bar(metaProgress) + ' ' + metaProgress + '%'
@@ -120,7 +121,7 @@ module.exports = function (type, opts, dat) {
     else progressOutput[4] = `Total size: ${st.filesTotal} ${st.filesTotal === 1 ? 'file' : 'files'} (${prettyBytes(st.bytesTotal)})`
 
     if (metaProgress < 100) debug('Metadata Download Progress:', metaProgress + '%')
-    if (contentProgress < 100) debug('Download Progress:', contentProgress + '%')
+    if (contentProgress < 100) debug('Download Progress:', contentProgress + '%', contentBlocksProgress, 'blocks of', st.blocksTotal)
   }
 
   function updateNetwork () {


### PR DESCRIPTION
Use hyperdrive-stats for block progress. `stats.blocksProgress` was off before related to our replication problems and downloading old files first.

Hyperdrive now downloads the latest files by default. hyperdrive-stats uses the same file list to count blocks, so it'll be more consistent to use that now.

Still need to look at the issue with stats.blockTotal, #638 (may also be related).