### PR TITLE
use dat-registry module, closes #660

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -17,7 +17,6 @@ var config = {
     { name: 'utp', default: true, boolean: true, help: 'use utp for discovery' },
     { name: 'debug', default: process.env.DEBUG }, // TODO: does not work right now
     { name: 'quiet', default: false, boolean: true },
-    { name: 'server', default: 'https://datproject.org/api/v1' },
     { name: 'verifyReplicationReads', default: true, boolean: true }
   ],
   root: {

--- a/lib/commands/auth/login.js
+++ b/lib/commands/auth/login.js
@@ -1,6 +1,6 @@
 var prompt = require('prompt')
 var ui = require('../../ui')
-var TownshipClient = require('../../township')
+var Registry = require('../../registry')
 
 module.exports = {
   name: 'login',
@@ -31,7 +31,7 @@ function login (opts) {
   })
 
   function makeRequest (user) {
-    var client = TownshipClient(opts)
+    var client = Registry(opts)
 
     client.login({
       email: user.email,

--- a/lib/commands/auth/logout.js
+++ b/lib/commands/auth/logout.js
@@ -1,5 +1,5 @@
 var ui = require('../../ui')
-var TownshipClient = require('../../township')
+var Registry = require('../../registry')
 
 module.exports = {
   name: 'logout',
@@ -8,9 +8,9 @@ module.exports = {
 }
 
 function logout (opts) {
-  var client = TownshipClient(opts)
+  var client = Registry(opts)
 
-  if (!client.getLogin().token) return ui.exitErr('Not logged in.')
+  if (!client.whoami().token) return ui.exitErr('Not logged in.')
   client.logout(function (err) {
     if (err) ui.exitErr(err)
     console.log('Logged out.')

--- a/lib/commands/auth/register.js
+++ b/lib/commands/auth/register.js
@@ -1,6 +1,6 @@
 var prompt = require('prompt')
 var ui = require('../../ui')
-var TownshipClient = require('../../township')
+var Registry = require('../../registry')
 
 module.exports = {
   name: 'register',
@@ -36,7 +36,7 @@ function register (opts) {
   })
 
   function makeRequest (user) {
-    var client = TownshipClient(opts)
+    var client = Registry(opts)
 
     client.register({
       email: user.email,

--- a/lib/commands/auth/whoami.js
+++ b/lib/commands/auth/whoami.js
@@ -1,5 +1,5 @@
 var ui = require('../../ui')
-var TownshipClient = require('../../township')
+var Registry = require('../../registry')
 
 module.exports = {
   name: 'whoami',
@@ -8,8 +8,8 @@ module.exports = {
 }
 
 function whoami (opts) {
-  var client = TownshipClient(opts)
-  var login = client.getLogin()
+  var client = Registry(opts)
+  var login = client.whoami()
   if (!login.token) return ui.exitErr('Not logged in.')
   console.log(login.email)
   process.exit(0)

--- a/lib/commands/publish.js
+++ b/lib/commands/publish.js
@@ -1,7 +1,7 @@
 var Dat = require('dat-node')
 var encoding = require('dat-encoding')
 var prompt = require('prompt')
-var TownshipClient = require('../township')
+var Registry = require('../registry')
 var ui = require('../ui')
 var datJson = require('../dat-json')
 
@@ -12,8 +12,8 @@ module.exports = {
 }
 
 function publish (opts) {
-  var client = TownshipClient(opts)
-  if (!client.getLogin().token) return ui.exitErr('Please login before publishing.')
+  var client = Registry(opts)
+  if (!client.whoami().token) return ui.exitErr('Please login before publishing.')
 
   opts.createIfMissing = false // publish must always be a resumed archive
   Dat(opts.dir, opts, function (err, dat) {

--- a/lib/registry.js
+++ b/lib/registry.js
@@ -1,5 +1,5 @@
 var xtend = require('xtend')
-var TownshipClient = require('township-client')
+var RegistryClient = require('dat-registry')
 
 module.exports = function (opts) {
   var townshipOpts = {
@@ -13,5 +13,5 @@ module.exports = function (opts) {
     // If we want a default, make sure it's not going to passed as undefined
   }
   var options = xtend(defaults, townshipOpts)
-  return TownshipClient(options)
+  return RegistryClient(options)
 }

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "dat-doctor": "^1.2.1",
     "dat-encoding": "^4.0.1",
     "dat-node": "^1.3.3",
+    "dat-registry": "^2.1.2",
     "debug": "^2.4.5",
     "memdb": "^1.3.1",
     "mkdirp": "^0.5.1",
@@ -44,7 +45,6 @@
     "rimraf": "^2.5.4",
     "status-logger": "^3.0.0",
     "subcommand": "^2.1.0",
-    "township-client": "^1.3.1",
     "xtend": "^4.0.1"
   },
   "devDependencies": {

--- a/tests/auth.js
+++ b/tests/auth.js
@@ -12,11 +12,12 @@ var baseTestDir = help.testFolder()
 var fixtures = path.join(__dirname, 'fixtures')
 
 var port = process.env.PORT || 3000
-var SERVER = 'http://localhost:' + port + '/api/v1'
+var SERVER = 'http://localhost:' + port
 var config = path.join(__dirname, '.datrc-test')
 var opts = ' --server=' + SERVER + ' --config=' + config
 
 dat += opts
+rimraf.sync(config)
 
 authServer(port, function (err, server, closeServer) {
   if (err) throw err
@@ -24,7 +25,7 @@ authServer(port, function (err, server, closeServer) {
     var cmd = dat + ' whoami '
     var st = spawn(t, cmd, {cwd: baseTestDir})
     st.stderr.match(function (output) {
-      t.same('Not logged in.', output.trim(), 'printed correct output')
+      t.same(output.trim(), 'Not logged in.', 'printed correct output')
       return true
     })
     st.stdout.empty()
@@ -66,6 +67,7 @@ authServer(port, function (err, server, closeServer) {
 
   test('auth - publish before create fails', function (t) {
     var cmd = dat + ' publish'
+    rimraf.sync(path.join(fixtures, '.dat'))
     var st = spawn(t, cmd, {cwd: fixtures})
     st.stdout.empty()
     st.stderr.match(function (output) {

--- a/tests/helpers/auth-server.js
+++ b/tests/helpers/auth-server.js
@@ -2,11 +2,16 @@ var path = require('path')
 var Server = require('dat-land/server')
 var initDb = require('dat-land/server/database/init')
 var rimraf = require('rimraf')
+var mockTransport = require('nodemailer-mock-transport')
 
 module.exports = createServer
 
 function createServer (port, cb) {
   var config = {
+    email: {
+      fromEmail: 'hi@example.com',
+      transport: mockTransport()
+    },
     township: {
       secret: 'very secret code',
       db: path.join(__dirname, '..', 'test-township.db')
@@ -16,12 +21,13 @@ function createServer (port, cb) {
       connection: { filename: path.join(__dirname, '..', 'test-sqlite.db') },
       useNullAsDefault: true
     },
-    archiver: path.join(__dirname, 'test-archiver'),
+    archiver: path.join(__dirname, '..', 'test-archiver'),
     whitelist: false,
     port: port || 8888
   }
   rimraf.sync(config.archiver)
   rimraf.sync(config.db.connection.filename)
+  rimraf.sync(config.township.db)
 
   initDb(config.db, function (err, db) {
     if (err) return cb(err)


### PR DESCRIPTION
* Uses the dat registry module instead of township client (#660)
* Updates some auth tests/config based on latest datproject.org repo updates.

Might add back `server` option to be `registry` or something with some help text instead.