### PR TITLE
do not run auth.js tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "auth-server": "DEBUG=* node scripts/auth-server.js",
     "install-precommit": "echo ./node_modules/.bin/standard > .git/hooks/pre-commit && chmod +x .git/hooks/pre-commit",
     "standard": "standard",
-    "test": "standard && tape tests/*.js | tap-spec"
+    "test": "standard && tape 'tests/*[!auth].js' | tap-spec"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Turning off auth tests for now. 

```
karissa> jhand: want to disable the register/login/publish tests until we actually deploy it for now, and then in the next week i'll roll out a dat-registry module that pulls out the database and api methods
karissa> jhand: no one is even using those features yet so testing them is premature i think, so i'm ok with disabling those tests
jhand> karissa: yep, sounds good!
```