### PR TITLE
Rename dat cli process title from dat-next to dat

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -7,7 +7,7 @@ var encoding = require('dat-encoding')
 var debug = require('debug')('dat')
 var usage = require('../lib/usage')
 
-process.title = 'dat-next'
+process.title = 'dat'
 
 var config = {
   defaults: [


### PR DESCRIPTION
I guess this was a leftover from when the new version of dat was being developed?