### PR TITLE
add peer debug info

### DIFF
--- a/src/extensions.js
+++ b/src/extensions.js
@@ -2,9 +2,9 @@ var debug = require('debug')('dat')
 
 module.exports = runExtension
 
-function runExtension(opts) {
+function runExtension (opts) {
   debug('Trying Extenion', opts._[0])
-  
+
   var extName = opts._.shift()
   trySpawn(function () {
     console.error('We could not run the extension. Please make sure it is installed:')
@@ -21,7 +21,7 @@ function runExtension(opts) {
       if (err.code === 'ENOENT') return cb()
       throw err
     })
-    child.on('close', function(code) {
+    child.on('close', function (code) {
       process.exit(code)
     })
   }

--- a/src/lib/network.js
+++ b/src/lib/network.js
@@ -21,7 +21,7 @@ function trackNetwork (state, bus) {
       })
     })
 
-    if (state.opts.peers) trackPeers()
+    if (state.opts.sources) trackSources()
     if (state.stats) return trackSpeed()
     bus.once('dat:stats', trackSpeed)
 
@@ -31,37 +31,37 @@ function trackNetwork (state, bus) {
       }, state.opts.logspeed)
     }
 
-    function trackPeers () {
-      state.peers = state.peers || {}
+    function trackSources () {
+      state.sources = state.sources || {}
       network.on('connection', function (conn, info) {
         var id = info.id.toString('hex')
         var peerSpeed = speed()
 
-        state.peers[id] = info
-        state.peers[id].speed = peerSpeed()
-        state.peers[id].getProgress = function () {
+        state.sources[id] = info
+        state.sources[id].speed = peerSpeed()
+        state.sources[id].getProgress = function () {
 
           // TODO: how to get right peer from archive.content?
           // var remote = conn.feeds[1].remoteLength
-          // // state.dat.archive.content.peers[0].feed.id.toString('hex')
+          // // state.dat.archive.content.sources[0].feed.id.toString('hex')
           // if (!remote) return
           // return remote / dat.archive.content.length
         }
 
         conn.feeds.map(function (feed) {
           feed.stream.on('data', function (data) {
-            state.peers[id].speed = peerSpeed(data.length)
+            state.sources[id].speed = peerSpeed(data.length)
             bus.emit('render')
           })
           feed.stream.on('error', function (err) {
-            state.peers[id].error = err
+            state.sources[id].error = err
           })
         })
         bus.emit('render')
 
         conn.on('close', function () {
-          state.peers[id].speed = 0
-          state.peers[id].closed = true
+          state.sources[id].speed = 0
+          state.sources[id].closed = true
           bus.emit('render')
         })
       })

--- a/src/lib/network.js
+++ b/src/lib/network.js
@@ -1,3 +1,4 @@
+var speed = require('speedometer')
 var xtend = Object.assign
 
 module.exports = trackNetwork
@@ -13,13 +14,14 @@ function trackNetwork (state, bus) {
     state.network = xtend(network, state.network)
     bus.emit('dat:network')
 
-    network.on('connection', function (peer) {
+    network.on('connection', function (conn, info) {
       bus.emit('render')
-      peer.on('close', function () {
+      conn.on('close', function () {
         bus.emit('render')
       })
     })
 
+    if (state.opts.peers) trackPeers()
     if (state.stats) return trackSpeed()
     bus.once('dat:stats', trackSpeed)
 
@@ -27,6 +29,42 @@ function trackNetwork (state, bus) {
       setInterval(function () {
         bus.emit('render')
       }, state.opts.logspeed)
+    }
+
+    function trackPeers () {
+      state.peers = state.peers || {}
+      network.on('connection', function (conn, info) {
+        var id = info.id.toString('hex')
+        var peerSpeed = speed()
+
+        state.peers[id] = info
+        state.peers[id].speed = peerSpeed()
+        state.peers[id].getProgress = function () {
+          return
+          // TODO: how to get right peer from archive.content?
+          // var remote = conn.feeds[1].remoteLength
+          // // state.dat.archive.content.peers[0].feed.id.toString('hex')
+          // if (!remote) return
+          // return remote / dat.archive.content.length
+        }
+
+        conn.feeds.map(function (feed) {
+          feed.stream.on('data', function (data) {
+            state.peers[id].speed = peerSpeed(data.length)
+            bus.emit('render')
+          })
+          feed.stream.on('error', function (err) {
+            state.peers[id].error = err
+          })
+        })
+        bus.emit('render')
+
+        conn.on('close', function () {
+          state.peers[id].speed = 0
+          state.peers[id].closed = true
+          bus.emit('render')
+        })
+      })
     }
   }
 }

--- a/src/lib/network.js
+++ b/src/lib/network.js
@@ -40,7 +40,7 @@ function trackNetwork (state, bus) {
         state.peers[id] = info
         state.peers[id].speed = peerSpeed()
         state.peers[id].getProgress = function () {
-          return
+
           // TODO: how to get right peer from archive.content?
           // var remote = conn.feeds[1].remoteLength
           // // state.dat.archive.content.peers[0].feed.id.toString('hex')

--- a/src/ui/archive.js
+++ b/src/ui/archive.js
@@ -5,6 +5,7 @@ var chalk = require('chalk')
 var downloadUI = require('./components/download')
 var importUI = require('./components/import-progress')
 var networkUI = require('./components/network')
+var peerUI = require('./components/peers')
 
 module.exports = archiveUI
 
@@ -29,7 +30,7 @@ function archiveUI (state) {
     ${state.joinNetwork ? '\n' + networkUI(state) : ''}
 
     ${state.writable ? importUI(state) : downloadUI(state)}
-
+    ${state.opts.peers ? peerUI(state) : ''}
     ${state.exiting ? 'Exiting the Dat program...' : chalk.dim('Ctrl+C to Exit')}
   `
 }

--- a/src/ui/archive.js
+++ b/src/ui/archive.js
@@ -5,7 +5,7 @@ var chalk = require('chalk')
 var downloadUI = require('./components/download')
 var importUI = require('./components/import-progress')
 var networkUI = require('./components/network')
-var peerUI = require('./components/peers')
+var sourcesUI = require('./components/sources')
 
 module.exports = archiveUI
 
@@ -30,7 +30,7 @@ function archiveUI (state) {
     ${state.joinNetwork ? '\n' + networkUI(state) : ''}
 
     ${state.writable ? importUI(state) : downloadUI(state)}
-    ${state.opts.peers ? peerUI(state) : ''}
+    ${state.opts.sources ? sourcesUI(state) : ''}
     ${state.exiting ? 'Exiting the Dat program...' : chalk.dim('Ctrl+C to Exit')}
   `
 }

--- a/src/ui/components/peers.js
+++ b/src/ui/components/peers.js
@@ -1,0 +1,39 @@
+var output = require('neat-log/output')
+var pretty = require('prettier-bytes')
+var makeBar = require('progress-string')
+
+module.exports = peersUI
+
+function peersUI (state) {
+  if (!state.network) return ''
+
+  var network = state.network
+  var stats = state.stats
+  var archive = state.dat.archive
+
+  if (Object.keys(state.peers).length === 0) return ''
+
+  var peers = state.peers
+  var peerCount = stats.peers.total || 0
+  var complete = stats.peers.complete
+  var info = Object.keys(peers).map(function (id, i) {
+    return peerUI(peers[id], i)
+  }).join('\n')
+
+  return `\n${info}\n`
+
+  function peerUI(peer, i) {
+    var progress = peer.getProgress()
+    var bar = makeBar({
+      total: 100,
+      style: function (a, b) {
+        return `[${a}${b}] ${(progress).toFixed(2)}%`
+      }
+    })
+    var theBar = progress ? bar(progress) : '' // progress bar todo
+    return output`
+      [${i}] ${peer.closed ? 'CLOSED' : peer.type}: ${peer.host}:${peer.port} ${pretty(peer.speed)}/s
+      ${peer.error ? peer.error : theBar}
+    `
+  }
+}

--- a/src/ui/components/peers.js
+++ b/src/ui/components/peers.js
@@ -6,23 +6,19 @@ module.exports = peersUI
 
 function peersUI (state) {
   if (!state.network) return ''
-
-  var network = state.network
-  var stats = state.stats
-  var archive = state.dat.archive
-
   if (Object.keys(state.peers).length === 0) return ''
 
   var peers = state.peers
-  var peerCount = stats.peers.total || 0
-  var complete = stats.peers.complete
+  // var stats = state.stats
+  // var peerCount = stats.peers.total || 0
+  // var complete = stats.peers.complete
   var info = Object.keys(peers).map(function (id, i) {
     return peerUI(peers[id], i)
   }).join('\n')
 
   return `\n${info}\n`
 
-  function peerUI(peer, i) {
+  function peerUI (peer, i) {
     var progress = peer.getProgress()
     var bar = makeBar({
       total: 100,

--- a/src/ui/components/sources.js
+++ b/src/ui/components/sources.js
@@ -6,9 +6,9 @@ module.exports = peersUI
 
 function peersUI (state) {
   if (!state.network) return ''
-  if (Object.keys(state.peers).length === 0) return ''
+  if (Object.keys(state.sources).length === 0) return ''
 
-  var peers = state.peers
+  var peers = state.sources
   // var stats = state.stats
   // var peerCount = stats.peers.total || 0
   // var complete = stats.peers.complete


### PR DESCRIPTION
Adds a `--peers` option to show all the peer connections. 

```
[0] tcp: 104.197.61.181:34536 0.4 B/s

[1] CLOSED: ::ffff:10.0.1.68:3282 0 B/s

[2] utp: 72.182.35.118:58054 34 B/s
```

I wanted to add the progress bar to the space but had a bit of trouble implementing it. The `conn.feeds[1].remoteLength` didn't seem to populate and I wasn't sure how to tell which peer was which in `archive.content.peers`.