### PR TITLE
Add --http option to serve archive over http while syncing

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -22,6 +22,7 @@ var config = {
     { name: 'logspeed', default: 400 },
     { name: 'port', default: 3282, help: 'port to use for connections' },
     { name: 'utp', default: true, boolean: true, help: 'use utp for discovery' },
+    { name: 'http', help: 'serve dat over http. Default port is 8080 or pass custom port.' },
     { name: 'quiet', default: isDebug, boolean: true } // neat-log uses quiet for debug right now
   ],
   root: {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "dat-node": "^3.3.0",
     "dat-registry": "^2.1.2",
     "debug": "^2.6.6",
+    "hyperdrive-http": "^4.0.1",
     "mkdirp": "^0.5.1",
     "neat-log": "^1.1.0",
     "nets": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "dat-node": "^3.3.0",
     "dat-registry": "^2.1.2",
     "debug": "^2.6.6",
-    "hyperdrive-http": "^4.0.1",
+    "hyperdrive-http": "^4.1.0",
     "mkdirp": "^0.5.1",
     "neat-log": "^1.1.0",
     "nets": "^3.2.0",

--- a/src/lib/archive.js
+++ b/src/lib/archive.js
@@ -2,6 +2,7 @@ var doImport = require('./import-progress')
 var stats = require('./stats')
 var network = require('./network')
 var download = require('./download')
+var serve = require('./serve-http')
 
 module.exports = function (state, bus) {
   bus.once('dat', function () {
@@ -10,6 +11,7 @@ module.exports = function (state, bus) {
 
     stats(state, bus)
     if (state.joinNetwork) network(state, bus)
+    if (state.opts.http) serve(state, bus)
 
     if (state.writable) doImport(state, bus)
     else download(state, bus)

--- a/src/lib/serve-http.js
+++ b/src/lib/serve-http.js
@@ -5,7 +5,9 @@ module.exports = runHttp
 
 function runHttp (state, bus) {
   var port = (typeof state.opts.http === 'boolean') ? 8080 : state.opts.http
-  var server = http.createServer(serve(state.dat.archive, {live: true}))
+  var footer = 'Served via Dat.'
+  // TODO: opts.exposeHeaders = true? Also exposes key which we mat not always want.
+  var server = http.createServer(serve(state.dat.archive, {live: true, footer: footer}))
   server.listen(port)
   server.on('listening', function () {
     state.http = { port: port, listening: true }

--- a/src/lib/serve-http.js
+++ b/src/lib/serve-http.js
@@ -1,0 +1,14 @@
+var http = require('http')
+var serve = require('hyperdrive-http')
+
+module.exports = runHttp
+
+function runHttp (state, bus) {
+  var port = (typeof state.opts.http === 'boolean') ? 8080 : state.opts.http
+  var server = http.createServer(serve(state.dat.archive, {live: true}))
+  server.listen(port)
+  server.on('listening', function () {
+    state.http = { port: port, listening: true }
+    bus.emit('render')
+  })
+}

--- a/src/ui/archive.js
+++ b/src/ui/archive.js
@@ -24,6 +24,7 @@ function archiveUI (state) {
   else if (state.writable) title += 'Sharing dat'
   else title += 'Downloading dat'
   if (stats.version) title += `: ${stats.files} files (${pretty(stats.byteLength)})`
+  if (state.http && state.http.listening) title += `\nServing files over http at http://localhost:${state.http.port}`
 
   return output`
     ${title}


### PR DESCRIPTION
`--http` option serves archive via hyperdrive-http while syncing:

<img width="778" alt="screen shot 2017-05-11 at 12 10 57 pm" src="https://cloud.githubusercontent.com/assets/684965/25967453/0bd80136-3643-11e7-8888-3e52092d8413.png">

Port can be also specified `--http=9000`.