### PR TITLE
Add prompt and dat.json to dat create

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "cli-truncate": "^1.0.0",
     "dat-doctor": "^1.2.5",
     "dat-encoding": "^4.0.2",
+    "dat-json": "^1.0.0",
     "dat-link-resolve": "^1.0.0",
     "dat-node": "^3.3.0",
     "dat-registry": "^2.1.2",

--- a/src/commands/create.js
+++ b/src/commands/create.js
@@ -93,7 +93,7 @@ function create (opts) {
         prompt.get(schema, writeDatJson)
 
         function writeDatJson (err, results) {
-          if (err) return console.log(err.message) // prompt error
+          if (err) return bus.emit('exit:error', err) // prompt error
           if (results.doImport[0] === 'y') state.opts.import = true
           if (!results.title && !results.description) return done()
           delete results.doImport // don't want this in dat.json

--- a/src/commands/create.js
+++ b/src/commands/create.js
@@ -56,9 +56,8 @@ function create (opts) {
       if (err && err.name === 'ExistsError') return bus.emit('exit:warn', 'Archive already exists.')
       if (err) return bus.emit('exit:error', err)
 
-
       // create before import
-      datjson = DatJson(dat.archive, { file: path.join(opts.dir, 'dat.json') })
+      var datjson = DatJson(dat.archive, { file: path.join(opts.dir, 'dat.json') })
       fs.readFile(path.join(opts.dir, 'dat.json'), 'utf-8', function (err, data) {
         if (err) return doPrompt()
         data = JSON.parse(data)
@@ -66,7 +65,7 @@ function create (opts) {
         doPrompt(data)
       })
 
-      function doPrompt(data) {
+      function doPrompt (data) {
         if (!data) data = {}
 
         var schema = {
@@ -74,8 +73,8 @@ function create (opts) {
             title: {
               description: chalk.magenta('Dat Title'),
               default: data.title || '',
-              pattern: /^[a-zA-Z\s\-]+$/,
-              message: 'Name must be only letters, spaces, or dashes',
+              // pattern: /^[a-zA-Z\s\-]+$/,
+              // message: 'Name must be only letters, spaces, or dashes',
               required: false
             },
             description: {
@@ -89,7 +88,7 @@ function create (opts) {
           }
         }
         prompt.message = chalk.green('> ')
-        prompt.delimiter = '' //chalk.cyan('')
+        prompt.delimiter = '' // chalk.cyan('')
         prompt.start()
         prompt.get(schema, writeDatJson)
 

--- a/src/commands/create.js
+++ b/src/commands/create.js
@@ -59,7 +59,7 @@ function create (opts) {
       // create before import
       var datjson = DatJson(dat.archive, { file: path.join(opts.dir, 'dat.json') })
       fs.readFile(path.join(opts.dir, 'dat.json'), 'utf-8', function (err, data) {
-        if (err) return doPrompt()
+        if (err || !data) return doPrompt()
         data = JSON.parse(data)
         debug('read existing dat.json data', data)
         doPrompt(data)
@@ -86,6 +86,11 @@ function create (opts) {
               default: 'yes'
             }
           }
+        }
+        if (opts.title || opts.description) {
+          // avoid setting import unless these title/desc are set
+          var doImport = opts.import ? 'yes' : 'no'
+          prompt.override = { title: opts.title, description: opts.description, doImport: doImport }
         }
         prompt.message = chalk.green('> ')
         prompt.delimiter = '' // chalk.cyan('')

--- a/src/lib/import-progress.js
+++ b/src/lib/import-progress.js
@@ -10,6 +10,7 @@ function trackImport (state, bus) {
     var progress = state.dat.importFiles(state.opts, function (err) {
       if (err) return bus.emit('exit:error', err)
       state.importer.fileImport = null
+      state.exiting = true
       bus.emit('render')
     })
     state.importer = xtend({

--- a/src/ui/archive.js
+++ b/src/ui/archive.js
@@ -24,7 +24,7 @@ function archiveUI (state) {
   if (state.title) title += state.title
   else if (state.writable) title += 'Sharing dat'
   else title += 'Downloading dat'
-  if (stats.version > 0) title += `: ${stats.files} files (${pretty(stats.byteLength)})`
+  if (stats.version > 0) title += `: ${stats.files} ${pluralize('file', stats.file)} (${pretty(stats.byteLength)})`
   else if (stats.version === 0) title += ': (empty archive)'
   if (state.http && state.http.listening) title += `\nServing files over http at http://localhost:${state.http.port}`
 
@@ -46,4 +46,8 @@ function archiveUI (state) {
     ${state.opts.sources ? sourcesUI(state) : ''}
     ${state.exiting ? 'Exiting the Dat program...' : chalk.dim('Ctrl+C to Exit')}
   `
+
+  function pluralize (str, val) {
+    return `${str}${val === 1 ? '' : 's'}`
+  }
 }

--- a/src/ui/archive.js
+++ b/src/ui/archive.js
@@ -1,11 +1,12 @@
 var output = require('neat-log/output')
-var stringKey = require('dat-encoding').toStr
 var pretty = require('prettier-bytes')
 var chalk = require('chalk')
 var downloadUI = require('./components/download')
 var importUI = require('./components/import-progress')
 var networkUI = require('./components/network')
 var sourcesUI = require('./components/sources')
+var keyEl = require('./elements/key')
+var pluralize = require('./elements/pluralize')
 
 module.exports = archiveUI
 
@@ -19,7 +20,7 @@ function archiveUI (state) {
   var progressView
 
   if (state.writable || state.opts.showKey) {
-    title = `${chalk.blue('dat://' + stringKey(dat.key))}\n`
+    title = `${keyEl(dat.key)}\n`
   }
   if (state.title) title += state.title
   else if (state.writable) title += 'Sharing dat'
@@ -46,8 +47,4 @@ function archiveUI (state) {
     ${state.opts.sources ? sourcesUI(state) : ''}
     ${state.exiting ? 'Exiting the Dat program...' : chalk.dim('Ctrl+C to Exit')}
   `
-
-  function pluralize (str, val) {
-    return `${str}${val === 1 ? '' : 's'}`
-  }
 }

--- a/src/ui/components/network.js
+++ b/src/ui/components/network.js
@@ -1,5 +1,6 @@
 var output = require('neat-log/output')
 var pretty = require('prettier-bytes')
+var pluralize = require('../elements/pluralize')
 
 module.exports = networkUI
 
@@ -22,9 +23,5 @@ function networkUI (state) {
     output += `Download ${pretty(downSpeed)}/s`
     output += ` Upload ${pretty(upSpeed)}/s `
     return output
-  }
-
-  function pluralize (str, val) {
-    return `${str}${val === 1 ? '' : 's'}`
   }
 }

--- a/src/ui/create.js
+++ b/src/ui/create.js
@@ -15,14 +15,19 @@ function createUI (state) {
 
   var dat = state.dat
   var stats = dat.stats.get()
-  var title = ''
+  var title = '\n'
   var progressView
   var exitMsg = `
     Your dat is created! Run ${chalk.green('dat sync')} to share:
     ${chalk.blue('dat://' + stringKey(dat.key))}
   `
+  if (!state.opts.import) {
+    // set exiting right away
+    state.exiting = true
+  }
 
-  if (state.writable || state.opts.showKey) {
+  if (!state.exiting) {
+    // Only show key if not about to exit
     title = `${chalk.blue('dat://' + stringKey(dat.key))}\n`
   }
   if (state.title) title += state.title
@@ -31,16 +36,15 @@ function createUI (state) {
   else if (stats.version === 0) title += ': (empty archive)'
 
   if (state.opts.import) {
-    progressView = importUI(state)
+    progressView = importUI(state) + '\n'
   } else {
-    state.exiting = true
     progressView = 'Not importing files.'
   }
+
   return output`
     ${title}
 
     ${progressView}
-
     ${state.exiting ? exitMsg : chalk.dim('Ctrl+C to Exit')}
   `
 

--- a/src/ui/create.js
+++ b/src/ui/create.js
@@ -1,8 +1,9 @@
 var output = require('neat-log/output')
-var stringKey = require('dat-encoding').toStr
 var pretty = require('prettier-bytes')
 var chalk = require('chalk')
 var importUI = require('./components/import-progress')
+var keyEl = require('./elements/key')
+var pluralize = require('./elements/pluralize')
 
 module.exports = createUI
 
@@ -19,7 +20,7 @@ function createUI (state) {
   var progressView
   var exitMsg = `
     Your dat is created! Run ${chalk.green('dat sync')} to share:
-    ${chalk.blue('dat://' + stringKey(dat.key))}
+    ${keyEl(dat.key)}
   `
   if (!state.opts.import) {
     // set exiting right away
@@ -28,7 +29,7 @@ function createUI (state) {
 
   if (!state.exiting) {
     // Only show key if not about to exit
-    title = `${chalk.blue('dat://' + stringKey(dat.key))}\n`
+    title = `${keyEl(dat.key)}\n`
   }
   if (state.title) title += state.title
 
@@ -47,8 +48,4 @@ function createUI (state) {
     ${progressView}
     ${state.exiting ? exitMsg : chalk.dim('Ctrl+C to Exit')}
   `
-
-  function pluralize (str, val) {
-    return `${str}${val === 1 ? '' : 's'}`
-  }
 }

--- a/src/ui/create.js
+++ b/src/ui/create.js
@@ -7,9 +7,11 @@ var importUI = require('./components/import-progress')
 module.exports = createUI
 
 function createUI (state) {
-  if (!state.dat) return output`
+  if (!state.dat) {
+    return output`
     Creating a Dat! Add information to your dat.json file:
   `
+  }
 
   var dat = state.dat
   var stats = dat.stats.get()

--- a/src/ui/create.js
+++ b/src/ui/create.js
@@ -1,0 +1,48 @@
+var output = require('neat-log/output')
+var stringKey = require('dat-encoding').toStr
+var pretty = require('prettier-bytes')
+var chalk = require('chalk')
+var importUI = require('./components/import-progress')
+
+module.exports = createUI
+
+function createUI (state) {
+  if (!state.dat) return output`
+    Creating a Dat! Add information to your dat.json file:
+  `
+
+  var dat = state.dat
+  var stats = dat.stats.get()
+  var title = ''
+  var progressView
+  var exitMsg = `
+    Your dat is created! Run ${chalk.green('dat sync')} to share:
+    ${chalk.blue('dat://' + stringKey(dat.key))}
+  `
+
+  if (state.writable || state.opts.showKey) {
+    title = `${chalk.blue('dat://' + stringKey(dat.key))}\n`
+  }
+  if (state.title) title += state.title
+
+  if (stats.version > 0) title += `: ${stats.files} ${pluralize('file', stats.files)} (${pretty(stats.byteLength)})`
+  else if (stats.version === 0) title += ': (empty archive)'
+
+  if (state.opts.import) {
+    progressView = importUI(state)
+  } else {
+    state.exiting = true
+    progressView = 'Not importing files.'
+  }
+  return output`
+    ${title}
+
+    ${progressView}
+
+    ${state.exiting ? exitMsg : chalk.dim('Ctrl+C to Exit')}
+  `
+
+  function pluralize (str, val) {
+    return `${str}${val === 1 ? '' : 's'}`
+  }
+}

--- a/src/ui/elements/key.js
+++ b/src/ui/elements/key.js
@@ -1,0 +1,6 @@
+var stringKey = require('dat-encoding').toStr
+var chalk = require('chalk')
+
+module.exports = function (key) {
+  return `${chalk.blue(`dat://${stringKey(key)}`)}`
+}

--- a/src/ui/elements/pluralize.js
+++ b/src/ui/elements/pluralize.js
@@ -1,0 +1,3 @@
+module.exports = function pluralize (str, val) {
+  return `${str}${val === 1 ? '' : 's'}`
+}

--- a/test/create.js
+++ b/test/create.js
@@ -17,7 +17,7 @@ try { fs.unlinkSync(path.join(fixtures, 'dat.json')) } catch (e) { /* ignore err
 
 test('create - default opts no import', function (t) {
   tempDir(function (_, dir, cleanup) {
-    var cmd = dat + ' create'
+    var cmd = dat + ' create --title data --description thing'
     var st = spawn(t, cmd, {cwd: dir})
 
     st.stdout.match(function (output) {
@@ -37,7 +37,7 @@ test('create - default opts no import', function (t) {
 
 test('create - default opts with import', function (t) {
   tempDir(function (_, dir, cleanup) {
-    var cmd = dat + ' create --import'
+    var cmd = dat + ' create --title data --description thing --import'
     var st = spawn(t, cmd, {cwd: dir})
 
     st.stdout.match(function (output) {
@@ -62,7 +62,7 @@ test('create - errors on existing archive', function (t) {
     Dat(dir, function (err, dat) {
       t.error(err, 'no error')
       dat.close(function () {
-        var cmd = dat + ' create'
+        var cmd = dat + ' create --title data --description thing'
         var st = spawn(t, cmd, {cwd: dir})
         st.stderr.match(function (output) {
           t.ok(output, 'errors')
@@ -77,7 +77,7 @@ test('create - errors on existing archive', function (t) {
 
 test('create - sync after create ok', function (t) {
   tempDir(function (_, dir, cleanup) {
-    var cmd = dat + ' create'
+    var cmd = dat + ' create --title data --description thing'
     var st = spawn(t, cmd, {cwd: dir, end: false})
     st.stdout.match(function (output) {
       var connected = output.indexOf('Not importing files') > -1
@@ -104,7 +104,7 @@ test('create - sync after create ok', function (t) {
 
 test('create - init alias', function (t) {
   tempDir(function (_, dir, cleanup) {
-    var cmd = dat + ' init'
+    var cmd = dat + ' init --title data --description thing'
     var st = spawn(t, cmd, {cwd: dir})
 
     st.stdout.match(function (output) {
@@ -124,7 +124,7 @@ test('create - init alias', function (t) {
 
 test('create - with path', function (t) {
   tempDir(function (_, dir, cleanup) {
-    var cmd = dat + ' init ' + dir
+    var cmd = dat + ' init ' + dir + ' --title data --description thing'
     var st = spawn(t, cmd)
     st.stdout.match(function (output) {
       var datCreated = output.indexOf('Not importing files') > -1


### PR DESCRIPTION
With this PR `dat create` will now:

* prompt users to add title, description to dat.json (reads any dat.json already present)
* Asks user if they want to import.

With Importing example:

![screen shot 2017-05-16 at 19 25 07](https://cloud.githubusercontent.com/assets/684965/26135886/66eba0ea-3a6d-11e7-8ed6-9d9f6bd734dc.png)

Not importing example:

![screen shot 2017-05-16 at 19 23 24](https://cloud.githubusercontent.com/assets/684965/26135857/3152d3ae-3a6d-11e7-85db-9f3fed4d3dad.png)
