### PR TITLE
Add `dat log` command

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -42,6 +42,7 @@ var config = {
     require('../src/commands/clone'),
     require('../src/commands/create'),
     require('../src/commands/doctor'),
+    require('../src/commands/log'),
     require('../src/commands/publish'),
     require('../src/commands/pull'),
     require('../src/commands/share'),
@@ -62,7 +63,7 @@ var config = {
   aliases: {
     'init': 'create'
   },
-  extensions: ['log'] // whitelist extensions for now
+  extensions: [] // whitelist extensions for now
 }
 
 if (debug.enabled) {

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -62,7 +62,7 @@ var config = {
   aliases: {
     'init': 'create'
   },
-  extensions: ['ls'] // whitelist extensions for now
+  extensions: ['log'] // whitelist extensions for now
 }
 
 if (debug.enabled) {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "auth-server": "DEBUG=* node scripts/auth-server.js",
     "install-precommit": "echo ./node_modules/.bin/standard > .git/hooks/pre-commit && chmod +x .git/hooks/pre-commit",
     "standard": "standard",
-    "deps": "dependency-check . -i dat-log && dependency-check . --extra --no-dev -i dat-log",
+    "deps": "dependency-check . && dependency-check . --extra --no-dev",
     "test": "standard && npm run deps && tape 'test/*[!auth].js' | tap-spec"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "dat-encoding": "^4.0.2",
     "dat-json": "^1.0.0",
     "dat-link-resolve": "^1.0.0",
-    "dat-log": "^1.0.0",
+    "dat-log": "^1.1.0",
     "dat-node": "^3.3.0",
     "dat-registry": "^2.1.2",
     "debug": "^2.6.6",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "decentralized",
     "file sharing"
   ],
-  "main" : "index.js",
+  "main": "index.js",
   "bin": {
     "dat": "bin/cli.js"
   },
@@ -16,7 +16,7 @@
     "auth-server": "DEBUG=* node scripts/auth-server.js",
     "install-precommit": "echo ./node_modules/.bin/standard > .git/hooks/pre-commit && chmod +x .git/hooks/pre-commit",
     "standard": "standard",
-    "deps": "dependency-check . && dependency-check . --extra --no-dev",
+    "deps": "dependency-check . -i dat-log && dependency-check . --extra --no-dev -i dat-log",
     "test": "standard && npm run deps && tape 'test/*[!auth].js' | tap-spec"
   },
   "repository": {
@@ -39,6 +39,7 @@
     "dat-encoding": "^4.0.2",
     "dat-json": "^1.0.0",
     "dat-link-resolve": "^1.0.0",
+    "dat-log": "^1.0.0",
     "dat-node": "^3.3.0",
     "dat-registry": "^2.1.2",
     "debug": "^2.6.6",

--- a/src/commands/log.js
+++ b/src/commands/log.js
@@ -1,0 +1,19 @@
+var log = require('dat-log')
+
+module.exports = {
+  name: 'log',
+  help: [
+    'View history and information about a dat',
+    '',
+    'Usage: dat log [dir|link]'
+  ].join('\n'),
+  options: [
+    {
+      name: 'live',
+      boolean: true,
+      default: false,
+      help: 'View live updates to history.'
+    }
+  ],
+  command: log
+}

--- a/src/usage.js
+++ b/src/usage.js
@@ -18,7 +18,7 @@ module.exports = function (opts, help, usage) {
   console.error('')
   console.error('Information:')
   console.error('   dat status                  get key & info about a local dat')
-  console.error('   dat ls                      list changes for a dat')
+  console.error('   dat log                     log history for a dat')
   console.error('')
   console.error('Troubleshooting & Help:')
   console.error('   dat doctor                  run the dat network doctor')


### PR DESCRIPTION
Uses [dat-log](https://github.com/joehand/dat-log) to log history and metadata. You can run on a local directory with `.dat` folder or a key, for example:

```
❯ dat log dat://64375abb733a62fa301b1f124427e825d292a6d3ba25a26c9d4303a7987bec65
1 [put] / 0 B (0 blocks)
2 [put] /README 175 B (1 block)
3 [put] /dat.json 309 B (1 block)
4 [put] /far-manzanar.csv 2.0 MB (31 blocks)
5 [put] /far-minidoka.csv 2.1 MB (33 blocks)
6 [put] /far-poston.csv 3.6 MB (55 blocks)
7 [put] /wra-master.csv 73 MB (1111 blocks)

Log synced with network

Archive has 7 changes (puts: +7, dels: -0)
Current Size: 80 MB
Total Size:
- Metadata 436 B
- Content 80 MB
Blocks:
- Metadata 8
- Content 1232
```