### PR TITLE
Add intro to create, make commands clear

### DIFF
--- a/src/commands/create.js
+++ b/src/commands/create.js
@@ -1,35 +1,27 @@
 var path = require('path')
 var fs = require('fs')
 var Dat = require('dat-node')
-var neatLog = require('neat-log')
+var output = require('neat-log/output')
 var DatJson = require('dat-json')
 var prompt = require('prompt')
 var chalk = require('chalk')
-var createUI = require('../ui/create')
-var trackArchive = require('../lib/archive')
-var onExit = require('../lib/exit')
 var debug = require('debug')('dat')
 
 module.exports = {
   name: 'create',
   command: create,
   help: [
-    'Create a local Dat archive to share',
+    'Create an empty dat and dat.json',
     '',
     'Usage: dat create [directory]'
   ].join('\n'),
   options: [
     {
-      name: 'import',
+      name: 'yes',
       boolean: true,
       default: false,
-      help: 'Import files from the directory'
-    },
-    {
-      name: 'ignoreHidden',
-      boolean: true,
-      default: true,
-      abbr: 'ignore-hidden'
+      abbr: 'y',
+      help: 'Skip dat.json creation.'
     }
   ]
 }
@@ -39,81 +31,97 @@ function create (opts) {
   if (opts._.length) opts.dir = opts._[0] // use first arg as dir if default set
   else if (!opts.dir) opts.dir = process.cwd()
 
+  var welcome = `Welcome to ${chalk.green(`dat`)} program!`
+  var intro = output`
+    You can turn any folder on your computer into a Dat.
+    A Dat is a folder with some magic.
+
+    Your dat is ready!
+    We will walk you creating a 'dat.json' file.
+    (You can skip dat.json and get started now.)
+
+    Learn more about dat.json: ${chalk.blue(`https://github.com/datprotocol/dat.json`)}
+
+    ${chalk.dim('Ctrl+C to exit at any time')}
+
+  `
+  var outro
+
   // Force certain options
   opts.errorIfExists = true
 
-  // Todo
-  // debug('Creating Dat archive in', opts.dir)
+  console.log(welcome)
+  Dat(opts.dir, opts, function (err, dat) {
+    if (err && err.name === 'ExistsError') return exitErr('\nArchive already exists.\nYou can use `dat sync` to update.')
+    if (err) return exitErr(err)
 
-  var neat = neatLog(createUI, { logspeed: opts.logspeed, quiet: opts.quiet })
-  neat.use(trackArchive)
-  neat.use(onExit)
-  neat.use(function (state, bus) {
-    state.opts = opts
-    state.joinNetwork = false
+    outro = output`
 
-    Dat(opts.dir, opts, function (err, dat) {
-      if (err && err.name === 'ExistsError') return bus.emit('exit:warn', 'Archive already exists.')
-      if (err) return bus.emit('exit:error', err)
+      Created empty Dat in ${dat.path}/.dat
 
-      // create before import
-      var datjson = DatJson(dat.archive, { file: path.join(opts.dir, 'dat.json') })
-      fs.readFile(path.join(opts.dir, 'dat.json'), 'utf-8', function (err, data) {
-        if (err || !data) return doPrompt()
-        data = JSON.parse(data)
-        debug('read existing dat.json data', data)
-        doPrompt(data)
-      })
+      Now you can add files and share:
+      * Run ${chalk.green(`dat share`)} to create metadata and sync.
+      * Copy the unique dat link and securly share it.
 
-      function doPrompt (data) {
-        if (!data) data = {}
+      ${chalk.blue(`dat://${dat.key.toString('hex')}`)}
+    `
 
-        var schema = {
-          properties: {
-            title: {
-              description: chalk.magenta('Dat Title'),
-              default: data.title || '',
-              // pattern: /^[a-zA-Z\s\-]+$/,
-              // message: 'Name must be only letters, spaces, or dashes',
-              required: false
-            },
-            description: {
-              description: chalk.magenta('Dat Description'),
-              default: data.description || ''
-            },
-            doImport: {
-              description: chalk.magenta('Would you like to import your files?'),
-              default: 'yes'
-            }
+    if (opts.yes) return done()
+
+    console.log(intro)
+    var datjson = DatJson(dat.archive, { file: path.join(opts.dir, 'dat.json') })
+    fs.readFile(path.join(opts.dir, 'dat.json'), 'utf-8', function (err, data) {
+      if (err || !data) return doPrompt()
+      data = JSON.parse(data)
+      debug('read existing dat.json data', data)
+      doPrompt(data)
+    })
+
+    function doPrompt (data) {
+      if (!data) data = {}
+
+      var schema = {
+        properties: {
+          title: {
+            description: chalk.magenta('Title'),
+            default: data.title || '',
+            // pattern: /^[a-zA-Z\s\-]+$/,
+            // message: 'Name must be only letters, spaces, or dashes',
+            required: false
+          },
+          description: {
+            description: chalk.magenta('Description'),
+            default: data.description || ''
           }
         }
-        if (opts.title || opts.description) {
-          // avoid setting import unless these title/desc are set
-          var doImport = opts.import ? 'yes' : 'no'
-          prompt.override = { title: opts.title, description: opts.description, doImport: doImport }
-        }
-        prompt.message = chalk.green('> ')
-        prompt.delimiter = '' // chalk.cyan('')
-        prompt.start()
-        prompt.get(schema, writeDatJson)
-
-        function writeDatJson (err, results) {
-          if (err) return bus.emit('exit:error', err) // prompt error
-          if (results.doImport[0] === 'y') state.opts.import = true
-          if (!results.title && !results.description) return done()
-          delete results.doImport // don't want this in dat.json
-          datjson.create(results, done)
-        }
-
-        function done (err) {
-          if (err) return bus.emit('exit:error', err)
-          state.title = 'Creating a new dat'
-          state.dat = dat
-          bus.emit('dat')
-          bus.emit('render')
-        }
       }
-      bus.emit('render')
-    })
+
+      prompt.override = { title: opts.title, description: opts.description }
+      prompt.message = chalk.green('> ')
+      prompt.delimiter = ''
+      prompt.start()
+      prompt.get(schema, writeDatJson)
+
+      function writeDatJson (err, results) {
+        if (err) return exitErr(err) // prompt error
+        if (!results.title && !results.description) return done()
+        datjson.create(results, done)
+      }
+    }
+
+    function done (err) {
+      if (err) return exitErr(err)
+      console.log(outro)
+    }
   })
+
+  function exitErr (err) {
+    if (err && err.message === 'canceled') {
+      console.log('')
+      console.log(outro)
+      process.exit(0)
+    }
+    console.error(err)
+    process.exit(1)
+  }
 }

--- a/src/commands/share.js
+++ b/src/commands/share.js
@@ -9,7 +9,7 @@ module.exports = {
   name: 'share',
   command: share,
   help: [
-    'Create and share a Dat archive',
+    'Create and share a dat',
     'Create a dat, import files, and share to the network.',
     '',
     'Usage: dat share'

--- a/src/commands/sync.js
+++ b/src/commands/sync.js
@@ -10,7 +10,7 @@ module.exports = {
   command: sync,
   help: [
     'Sync a Dat archive with the network',
-    'Watch and import file changes (if you created the archive)',
+    'Watch and import file changes (if archive is writable)',
     '',
     'Usage: dat sync'
   ].join('\n'),
@@ -19,7 +19,7 @@ module.exports = {
       name: 'import',
       boolean: true,
       default: true,
-      help: '(Dat Writable) Import files from the directory to the database (Dat Writable).'
+      help: 'Import files from the directory to the database (Dat Writable).'
     },
     {
       name: 'ignoreHidden',
@@ -37,6 +37,7 @@ module.exports = {
       name: 'show-key',
       boolean: true,
       default: false,
+      abbr: 'k',
       help: 'Print out the dat key (Dat Not Writable).'
     }
   ]

--- a/src/ui/archive.js
+++ b/src/ui/archive.js
@@ -16,11 +16,11 @@ function archiveUI (state) {
 
   var dat = state.dat
   var stats = dat.stats.get()
-  var title = ''
+  var title = (state.dat.resumed) ? '' : `Created new dat in ${dat.path}/.dat\n`
   var progressView
 
   if (state.writable || state.opts.showKey) {
-    title = `${keyEl(dat.key)}\n`
+    title += `${keyEl(dat.key)}\n`
   }
   if (state.title) title += state.title
   else if (state.writable) title += 'Sharing dat'

--- a/src/usage.js
+++ b/src/usage.js
@@ -4,28 +4,30 @@ module.exports = function (opts, help, usage) {
     console.error(pkg.version)
     process.exit(1)
   }
-  console.error('Usage: dat <cmd> [options]')
-  console.error('')
-  console.error('Sharing Files:')
-  console.error('   dat create [<dir>]          create a local archive')
-  console.error('   dat sync                    watch for changes & sync files')
-  console.error('   dat share                   create & sync archive in one command!')
-  console.error('')
-  console.error('Downloading Files:')
-  console.error('   dat clone <link> [<dir>]    clone a remote archive')
-  console.error('   dat pull                    update from remote archive & exit')
-  console.error('   dat sync                    sync files with the network')
-  console.error('')
-  console.error('Information:')
-  console.error('   dat status                  get key & info about a local dat')
-  console.error('   dat log                     log history for a dat')
-  console.error('')
-  console.error('Troubleshooting & Help:')
-  console.error('   dat doctor                  run the dat network doctor')
-  console.error('   dat help                    print this usage guide')
-  console.error('   dat <command> --help, -h    print help for a command')
-  console.error('   dat --version, -v           print the dat version')
-  console.error('')
+  var msg = `
+Usage: dat <cmd> [<dir>] [options]
+
+Sharing Files:
+   dat share                   create dat, import files, share to network
+   dat create                  create empty dat and dat.json
+   dat sync                    import files to existing dat & sync with network
+
+Downloading Files:
+   dat clone <link> [<dir>]    download a dat via link to <dir>
+   dat pull                    update dat & exit
+   dat sync                    live sync files with the network (upload + download)
+
+Info:
+   dat log                     log history for a dat
+   dat status                  get key & info about a local dat
+
+Troubleshooting & Help:
+   dat doctor                  run the dat network doctor
+   dat help                    print this usage guide
+   dat <command> --help, -h    print help for a specific command
+   dat --version, -v           print the dat version
+  `
+  console.error(msg)
   if (usage) {
     console.error('General Options:')
     console.error(usage)

--- a/test/create.js
+++ b/test/create.js
@@ -21,32 +21,10 @@ test('create - default opts no import', function (t) {
     var st = spawn(t, cmd, {cwd: dir})
 
     st.stdout.match(function (output) {
-      var datCreated = output.indexOf('Not importing files') > -1
+      var datCreated = output.indexOf('Created empty Dat') > -1
       if (!datCreated) return false
 
       t.ok(help.isDir(path.join(dir, '.dat')), 'creates dat directory')
-
-      st.kill()
-      return true
-    })
-    st.succeeds('exits after create finishes')
-    st.stderr.empty()
-    st.end(cleanup)
-  })
-})
-
-test('create - default opts with import', function (t) {
-  tempDir(function (_, dir, cleanup) {
-    var cmd = dat + ' create --title data --description thing --import'
-    var st = spawn(t, cmd, {cwd: dir})
-
-    st.stdout.match(function (output) {
-      var importFinished = output.indexOf('All files imported') > -1
-      if (!importFinished) return false
-
-      t.ok(help.isDir(path.join(dir, '.dat')), 'creates dat directory')
-      t.ok(help.matchLink(output), 'prints link')
-      t.skip(help.datJson(fixtures).title, 'fixtures', 'dat.json: has title')
 
       st.kill()
       return true
@@ -80,7 +58,7 @@ test('create - sync after create ok', function (t) {
     var cmd = dat + ' create --title data --description thing'
     var st = spawn(t, cmd, {cwd: dir, end: false})
     st.stdout.match(function (output) {
-      var connected = output.indexOf('Not importing files') > -1
+      var connected = output.indexOf('Created empty Dat') > -1
       if (!connected) return false
       doSync()
       return true
@@ -108,7 +86,7 @@ test('create - init alias', function (t) {
     var st = spawn(t, cmd, {cwd: dir})
 
     st.stdout.match(function (output) {
-      var datCreated = output.indexOf('Not importing files') > -1
+      var datCreated = output.indexOf('Created empty Dat') > -1
       if (!datCreated) return false
 
       t.ok(help.isDir(path.join(dir, '.dat')), 'creates dat directory')
@@ -127,7 +105,7 @@ test('create - with path', function (t) {
     var cmd = dat + ' init ' + dir + ' --title data --description thing'
     var st = spawn(t, cmd)
     st.stdout.match(function (output) {
-      var datCreated = output.indexOf('Not importing files') > -1
+      var datCreated = output.indexOf('Created empty Dat') > -1
       if (!datCreated) return false
 
       t.ok(help.isDir(path.join(dir, '.dat')), 'creates dat directory')


### PR DESCRIPTION
Create gives a little intro (similar to desktop app) and prompts for title + description to add to dat.json (it defaults to anything already in dat.json).

```
❯ dat create
Welcome to dat program!
You can turn any folder on your computer into a Dat.
A Dat is a folder with some magic.

Your dat is ready!
We will walk you creating a 'dat.json' file.
(You can skip dat.json and get started now.)

Learn more about dat.json: https://github.com/datprotocol/dat.json

Ctrl+C to exit at any time

> Title (DEMO) 
> Description My dataset

Dat created! Now you can add files and share:
* Run dat share to create metadata and sync.
* Copy the unique dat link and securly share it.

dat://91d70ae66ecbf5893228ca8c9414c97418832cb1b5675879027422da6463b5ca
```

You can skip the intro/prompts with `dat create -y`.
