### PR TITLE
turn on upload/announce for now, closes #783

### DIFF
--- a/src/commands/clone.js
+++ b/src/commands/clone.js
@@ -21,8 +21,8 @@ module.exports = {
     {
       name: 'upload',
       boolean: true,
-      default: false,
-      help: 'upload data to other peers while cloning'
+      default: true,
+      help: 'announce your address on link (improves connection capability) and upload data to other downloaders.'
     },
     {
       name: 'show-key',

--- a/src/commands/pull.js
+++ b/src/commands/pull.js
@@ -18,8 +18,8 @@ module.exports = {
     {
       name: 'upload',
       boolean: true,
-      default: false,
-      help: 'upload data to other peers while pulling'
+      default: true,
+      help: 'announce your address on link (improves connection capability) and upload data to other downloaders.'
     },
     {
       name: 'show-key',


### PR DESCRIPTION
We need announce for hole-punching. 

* Turned on `--upload` by default in `dat clone` and `dat pull`.
* Clarified in upload help what it does.

Upload and announce should be separate options in the future, https://github.com/datproject/dat-node/issues/150.