### PR TITLE
Print version number in header

### DIFF
--- a/src/ui/archive.js
+++ b/src/ui/archive.js
@@ -7,6 +7,8 @@ var networkUI = require('./components/network')
 var sourcesUI = require('./components/sources')
 var keyEl = require('./elements/key')
 var pluralize = require('./elements/pluralize')
+var version = require('./elements/version')
+var pkg = require('../../package.json')
 
 module.exports = archiveUI
 
@@ -40,6 +42,7 @@ function archiveUI (state) {
   }
 
   return output`
+    ${version(pkg.version)}
     ${title}
     ${state.joinNetwork ? '\n' + networkUI(state) : ''}
 

--- a/src/ui/elements/version.js
+++ b/src/ui/elements/version.js
@@ -1,0 +1,5 @@
+var chalk = require('chalk')
+
+module.exports = function (version) {
+  return `${chalk.green(`dat v${version}`)}`
+}


### PR DESCRIPTION
Prints current version number to header (in green!):

<img width="496" alt="screen shot 2017-05-25 at 12 26 00" src="https://cloud.githubusercontent.com/assets/684965/26466935/69382e16-4145-11e7-8a78-2e4946c3a95f.png">
