### PR TITLE
add g++ 4.8 to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,21 @@
 language: node_js
 
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - g++-4.8
+
 node_js:
   - "4"
   - "6"
   - "8"
 
 sudo: false
+
+before_install:
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then export CXX=g++-4.8; fi
 
 script:
  - npm test


### PR DESCRIPTION
We need 4.8 compiler because `node-sass` doesn't have any precompiled binaries for node 8