### PR TITLE
Publish metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "dat-link-resolve": "^1.0.0",
     "dat-log": "^1.1.0",
     "dat-node": "^3.3.2",
-    "dat-registry": "^3.0.2",
+    "dat-registry": "^3.0.3",
     "debug": "^2.6.6",
     "hyperdrive-http": "^4.1.0",
     "neat-log": "^1.1.0",

--- a/src/commands/publish.js
+++ b/src/commands/publish.js
@@ -95,13 +95,21 @@ function publish (opts) {
     }
 
     function makeRequest (datInfo) {
-      console.log(`'${chalk.bold(datInfo.name)}' will soon be ready for its great unveiling.`)
+      console.log(`Please wait, '${chalk.bold(datInfo.name)}' will soon be ready for its great unveiling...`)
       client.dats.create(datInfo, function (err, resp, body) {
         if (err) {
-          if (err.message) return exitErr('ERROR: ' + err.message) // node error
+          if (err.message) {
+            if (err.message === 'timed out') {
+              return exitErr(output`${chalk.red('\nERROR: ' + opts.server + ' could not connect to your computer.')}
+              Troubleshoot here: ${chalk.green('https://docs.datproject.org/troubleshooting#networking-issues')}
+              `)
+            }
+            return exitErr('ERROR: ' + err.message) // node error
+          }
 
           // server response errors
-          if (err.toString().trim() === 'jwt expired') return exitErr(`Session expired, please ${chalk.green('dat login')} again`)
+          var str = err.toString().trim()
+          if (str === 'jwt expired') return exitErr(`Session expired, please ${chalk.green('dat login')} again`)
           return exitErr('ERROR: ' + err.toString())
         }
         if (body.statusCode === 400) return exitErr(new Error(body.message))

--- a/src/commands/publish.js
+++ b/src/commands/publish.js
@@ -53,6 +53,7 @@ function publish (opts) {
   Dat(opts.dir, opts, function (err, dat) {
     if (err) return exitErr(err)
     // TODO better error msg for non-existing archive
+    dat.joinNetwork()
 
     var datjson = DatJson(dat.archive, {file: path.join(dat.path, 'dat.json')})
     datjson.read(publish)

--- a/src/commands/publish.js
+++ b/src/commands/publish.js
@@ -51,9 +51,10 @@ function publish (opts) {
 
   opts.createIfMissing = false // publish must always be a resumed archive
   Dat(opts.dir, opts, function (err, dat) {
-    if (err) return exitErr(err)
-    // TODO better error msg for non-existing archive
-    dat.joinNetwork()
+    if (err && err.name === 'MissingError') return exitErr('No existing dat in this directory. Create a dat before publishing.')
+    else if (err) return exitErr(err)
+
+    dat.joinNetwork() // join network to upload metadata
 
     var datjson = DatJson(dat.archive, {file: path.join(dat.path, 'dat.json')})
     datjson.read(publish)

--- a/src/commands/publish.js
+++ b/src/commands/publish.js
@@ -104,12 +104,12 @@ function publish (opts) {
               Troubleshoot here: ${chalk.green('https://docs.datproject.org/troubleshooting#networking-issues')}
               `)
             }
+            var str = err.message.trim()
+            if (str === 'jwt expired') return exitErr(`Session expired, please ${chalk.green('dat login')} again`)
             return exitErr('ERROR: ' + err.message) // node error
           }
 
           // server response errors
-          var str = err.toString().trim()
-          if (str === 'jwt expired') return exitErr(`Session expired, please ${chalk.green('dat login')} again`)
           return exitErr('ERROR: ' + err.toString())
         }
         if (body.statusCode === 400) return exitErr(new Error(body.message))


### PR DESCRIPTION
This along with https://github.com/datproject/datproject.org/pull/594 will fix #803. That means when you `dat publish`, the registry will automatically pick up your metadata and have it ready for display so that even if the dat is down, we have a first picture of what the dat is. That also makes sure that the url is legit before allowing the publish to happen.

It also bumps dat-registry to 3.0.3 for a tiny bug fix.