### PR TITLE
add auth install to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ node_js:
 
 sudo: false
 
+before_script:
+ - npm install dat-registry-api --no-save
+
 script:
  - npm test
 


### PR DESCRIPTION
Trying to get auth tests to work (locally + travis), but can't get them to run.

@karissa were auth tests running with the dat-registry-api module at one point? [Right now](https://github.com/datproject/dat/blob/auth-tests/test/helpers/auth-server.js#L5-L6) it tries to require:

```js
  Server = require('dat-registry-api/server')
  initDb = require('dat-registry-api/server/database/init')
```

But doesn't seem like server is something in that module. What should we be requiring there?