### PR TITLE
make --http a boolean option

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -20,7 +20,7 @@ var config = {
     { name: 'logspeed', default: 400 },
     { name: 'port', default: 3282, help: 'port to use for connections' },
     { name: 'utp', default: true, boolean: true, help: 'use utp for discovery' },
-    { name: 'http', help: 'serve dat over http (default port: 8080)' },
+    { name: 'http', default: false, boolean: true, help: 'serve dat over http (default port: 8080)' },
     { name: 'quiet', default: isDebug, boolean: true }, // neat-log uses quiet for debug right now
     { name: 'sparse', default: false, boolean: true, help: 'download only requested data' },
     { name: 'up', help: 'throttle upload bandwidth (1024, 1kb, 2mb, etc.)' },


### PR DESCRIPTION
Allows doing `dat clone --http dat://live.mafintosh.com`, `dat --http .` etc.