### PR TITLE
added dat.json url parser to clone command.

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "cli-truncate": "^1.0.0",
     "dat-doctor": "^1.2.5",
     "dat-encoding": "^4.0.2",
-    "dat-is-link": "^1.0.0",
     "dat-json": "^1.0.0",
     "dat-link-resolve": "^1.0.0",
     "dat-log": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "cli-truncate": "^1.0.0",
     "dat-doctor": "^1.2.5",
     "dat-encoding": "^4.0.2",
+    "dat-is-link": "^1.0.0",
     "dat-json": "^1.0.0",
     "dat-link-resolve": "^1.0.0",
     "dat-log": "^1.1.0",

--- a/src/commands/clone.js
+++ b/src/commands/clone.js
@@ -66,7 +66,7 @@ function clone (opts) {
   if (isDatJson) {
     datPath = path.resolve(datPath)
   } else if (isDir) {
-    datPath = path.join(datPath + 'dat.json')
+    datPath = path.join(datPath + '/dat.json')
   }
 
   // if the datPath is valid parse it for a url key and set opts.key to the parsed url key.

--- a/src/commands/clone.js
+++ b/src/commands/clone.js
@@ -41,9 +41,23 @@ function clone (opts) {
   var onExit = require('../lib/exit')
   var parseArgs = require('../parse-args')
   var debug = require('debug')('dat')
-
   var parsed = parseArgs(opts)
+  var path = require('path')
+
   opts.key = parsed.key || opts._[0] // pass other links to resolver
+
+  // Resolves dat.json path and parses dat url from it.
+  // Null doesn't work yet. May have something to do with ../parse-args. Will submit issue.
+  if (opts.key === '.' || opts.key === null || path.basename(opts.key) === 'dat.json') {
+    var datPath = null
+    if (opts.key === '.' || opts.key === null) {
+      datPath = path.resolve('dat.json')
+    } else {
+      datPath = path.resolve(opts.key)
+    }
+    opts.key = JSON.parse(fs.readFileSync(datPath, 'utf8')).url
+  }
+
   opts.dir = parsed.dir
   opts.showKey = opts['show-key'] // using abbr in option makes printed help confusing
   opts.sparse = opts.empty

--- a/src/commands/clone.js
+++ b/src/commands/clone.js
@@ -66,7 +66,7 @@ function clone (opts) {
   if (isDatJson) {
     datPath = path.resolve(datPath)
   } else if (isDir) {
-    datPath = path.join(datPath + '/dat.json')
+    datPath = path.join(datPath + 'dat.json')
   }
 
   // if the datPath is valid parse it for a url key and set opts.key to the parsed url key.

--- a/src/commands/clone.js
+++ b/src/commands/clone.js
@@ -49,7 +49,7 @@ function clone (opts) {
 
   // Resolves dat.json path and parses dat url from it.
   if (opts.key === '.' || opts.key === undefined || path.basename(opts.key) === 'dat.json') {
-    var datPath = undefined
+    var datPath
     if (opts.key === '.' || opts.key === undefined) {
       datPath = path.resolve('dat.json')
     } else {

--- a/src/commands/clone.js
+++ b/src/commands/clone.js
@@ -31,6 +31,7 @@ module.exports = {
 
 function clone (opts) {
   var fs = require('fs')
+  var path = require('path')
   var rimraf = require('rimraf')
   var Dat = require('dat-node')
   var linkResolve = require('dat-link-resolve')
@@ -42,7 +43,6 @@ function clone (opts) {
   var parseArgs = require('../parse-args')
   var debug = require('debug')('dat')
   var parsed = parseArgs(opts)
-  var path = require('path')
   var isDatLink = require('dat-is-link')
 
   opts.key = parsed.key || opts._[0] // pass other links to resolver
@@ -58,7 +58,7 @@ function clone (opts) {
         datPath = path.resolve('dat.json')
         opts.dir = opts.key
       } else if (fs.existsSync(path.resolve(opts.key + '/dat.json'))) {
-        datPath = path.resolve(opts.key + 'dat.son')
+        datPath = path.resolve(opts.key + 'dat.json')
       } else if (path.basename(opts.key) === 'dat.json') {
         datPath = path.resolve(opts.key)
       }

--- a/src/commands/clone.js
+++ b/src/commands/clone.js
@@ -45,20 +45,20 @@ function clone (opts) {
   var path = require('path')
 
   opts.key = parsed.key || opts._[0] // pass other links to resolver
+  opts.dir = parsed.dir
 
   // Resolves dat.json path and parses dat url from it.
-  // Null doesn't work yet. May have something to do with ../parse-args. Will submit issue.
-  if (opts.key === '.' || opts.key === null || path.basename(opts.key) === 'dat.json') {
-    var datPath = null
-    if (opts.key === '.' || opts.key === null) {
+  if (opts.key === '.' || opts.key === undefined || path.basename(opts.key) === 'dat.json') {
+    var datPath = undefined
+    if (opts.key === '.' || opts.key === undefined) {
       datPath = path.resolve('dat.json')
     } else {
       datPath = path.resolve(opts.key)
     }
+    opts.dir = opts.dir || path.resolve('.') // if needed changes output directory from undefined to current.
     opts.key = JSON.parse(fs.readFileSync(datPath, 'utf8')).url
   }
 
-  opts.dir = parsed.dir
   opts.showKey = opts['show-key'] // using abbr in option makes printed help confusing
   opts.sparse = opts.empty
 

--- a/src/parse-args.js
+++ b/src/parse-args.js
@@ -40,6 +40,7 @@ module.exports = function (opts) {
   try {
     if (fs.statSync(opts._[0]).isDirectory()) {
       parsed.dir = opts._[0]
+      parsed.keyToDirSwitch = true // switch for clone dat.json resolution.
     }
   } catch (err) {
     if (err && !err.name === 'ENOENT') {


### PR DESCRIPTION
I've added dat.json url parser to the clone command as described in #639. `dat clone .`, `dat clone dat.json`, and `dat clone ./path/to/dat.json ./dir` should work as expected.

`dat clone ./path/to/dat.json` without a target directory specified creates a dat repo clone in the current working directory named after the key link that was parsed from dat.json.

`dat clone` does not yet work. It seems to have something to do with [src/parse-args.js](https://github.com/datproject/dat/blob/master/src/parse-args.js). I'll submit an issue about it.