### PR TITLE
added dat.json url parser to clone command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,17 @@ dat clone <dat-link> [<folder>] [--temp]
 Clone a remote Dat Archive to a local folder.
 This will create a folder with the key name is no folder is specified.
 
+#### Downloading via `dat.json` key
+
+You can use a `dat.json` file to clone also. This is useful when combining dat and git, for example. To clone a dat you can specify the path to a folder containing a `dat.json`:
+
+```
+git clone git@github.com:joehand/dat-clone-sparse-test.git
+dat clone ./dat-clone-sparse-test
+```
+
+This will download the dat specified in the `dat.json` file.
+
 #### Updating Downloaded Archives
 
 Once a Dat is clone, you can run either `dat pull` or `dat sync` in the folder to update the archive.

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "dat-log": "^1.1.0",
     "dat-node": "^3.5.0",
     "dat-registry": "^3.0.3",
-    "debug": "^2.6.6",
+    "debug": "^3.0.0",
     "neat-log": "^1.1.0",
     "prettier-bytes": "^1.0.3",
     "progress-string": "^1.2.1",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "cli-truncate": "^1.0.0",
     "dat-doctor": "^1.2.5",
     "dat-encoding": "^4.0.2",
-    "dat-is-link": "^1.0.0",
     "dat-json": "^1.0.0",
     "dat-link-resolve": "^1.0.0",
     "dat-log": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "cli-truncate": "^1.0.0",
     "dat-doctor": "^1.2.5",
     "dat-encoding": "^4.0.2",
+    "dat-is-link": "^1.0.0",
     "dat-json": "^1.0.0",
     "dat-link-resolve": "^1.0.0",
     "dat-log": "^1.1.0",

--- a/src/commands/clone.js
+++ b/src/commands/clone.js
@@ -47,8 +47,9 @@ function clone (opts) {
   opts.key = parsed.key || opts._[0] // pass other links to resolver
   opts.dir = parsed.dir
 
+  console.log(parsed.dir)
   // corrects parse-args.js default output for when no second argument for output directory is provided.
-  if (parsed.keyToDirSwitch) opts.dir = path.resolve('.')
+  if (parsed.keyToDirSwitch || parsed.dir === null) opts.dir = path.resolve('.')
 
   // variables needed to check if opts.key is on system and leads to a dat.json file.
   var datPath = opts.key

--- a/src/commands/clone.js
+++ b/src/commands/clone.js
@@ -63,7 +63,7 @@ function clone (opts) {
   if (isDatJson) {
     datPath = path.resolve(datPath)
   } else if (isDir) {
-    datPath = path.join(datPath + '/dat.json')
+    datPath = path.join(datPath, 'dat.json')
   }
 
   // if the datPath is valid parse it for a url key and set opts.key to the parsed url key.

--- a/src/commands/clone.js
+++ b/src/commands/clone.js
@@ -47,9 +47,8 @@ function clone (opts) {
   opts.key = parsed.key || opts._[0] // pass other links to resolver
   opts.dir = parsed.dir
 
-  console.log(parsed.dir)
   // corrects parse-args.js default output for when no second argument for output directory is provided.
-  if (parsed.keyToDirSwitch || parsed.dir === null) opts.dir = path.resolve('.')
+  if (parsed.keyCloneSwitch) opts.dir = path.resolve('.')
 
   // variables needed to check if opts.key is on system and leads to a dat.json file.
   var datPath = opts.key

--- a/src/commands/clone.js
+++ b/src/commands/clone.js
@@ -66,7 +66,7 @@ function clone (opts) {
   if (isDatJson) {
     datPath = path.resolve(datPath)
   } else if (isDir) {
-    datPath = path.join(datPath + 'dat.json')
+    datPath = path.join(datPath + '/dat.json')
   }
 
   // if the datPath is valid parse it for a url key and set opts.key to the parsed url key.

--- a/src/commands/clone.js
+++ b/src/commands/clone.js
@@ -41,9 +41,23 @@ function clone (opts) {
   var onExit = require('../lib/exit')
   var parseArgs = require('../parse-args')
   var debug = require('debug')('dat')
-
   var parsed = parseArgs(opts)
+  var path = require('path')
+
   opts.key = parsed.key || opts._[0] // pass other links to resolver
+
+  // Resolves dat.json path and parses dat url from it.
+  // Null doesn't work yet. May have something to do with ../parse-args. Will submit issue.
+  if (opts.key === '.' || opts.key === null || path.basename(opts.key) === 'dat.json') {
+    var datPath = null
+    if (opts.key === '.' || opts.key === null) {
+      datPath = path.resolve('dat.json')
+    } else {
+      datPath = path.resolve(opts.key)
+    }
+    opts.key = JSON.parse(fs.readFileSync(datPath, 'utf8')).url
+  }
+
   opts.dir = parsed.dir
   opts.showKey = opts['show-key'] // using abbr in option makes printed help confusing
   opts.sparse = opts.empty

--- a/src/commands/clone.js
+++ b/src/commands/clone.js
@@ -66,7 +66,7 @@ function clone (opts) {
   if (isDatJson) {
     datPath = path.resolve(datPath)
   } else if (isDir) {
-    datPath = path.join(datPath + '/dat.json')
+    datPath = path.join(datPath + 'dat.json')
   }
 
   // if the datPath is valid parse it for a url key and set opts.key to the parsed url key.

--- a/src/commands/clone.js
+++ b/src/commands/clone.js
@@ -121,20 +121,17 @@ function clone (opts) {
   })
 
   function getDatJsonKey () {
-     // variables needed to check if opts.key is on system and leads to a dat.json file.
     var datPath = opts.key
     var stat = fs.lstatSync(datPath)
-    var isDir = stat.isDirectory()
-    var isDatJson = (fs.lstatSync(datPath).isFile() && (path.basename(datPath) === 'dat.json'))
 
-    // if file is a dat.json resolve absolute path. else if directory try to resolve path to dat.json.
-    if (isDatJson) {
-      datPath = path.resolve(datPath)
-    } else if (isDir) {
-      datPath = path.join(datPath, 'dat.json')
+    if (stat.isDirectory()) datPath = path.join(datPath, 'dat.json')
+
+    if (!fs.existsSync(datPath) || path.basename(datPath) !== 'dat.json') {
+      if (stat.isFile()) throw new Error('must specify existing dat.json file to read key')
+      throw new Error('directory must contain a dat.json')
     }
 
-    // if the datPath is valid parse it for a url key and set opts.key to the parsed url key.
+    debug('reading key from dat.json:', datPath)
     return JSON.parse(fs.readFileSync(datPath, 'utf8')).url
   }
 }

--- a/src/commands/clone.js
+++ b/src/commands/clone.js
@@ -49,7 +49,7 @@ function clone (opts) {
 
   // Resolves dat.json path and parses dat url from it.
   if (opts.key === '.' || opts.key === undefined || path.basename(opts.key) === 'dat.json') {
-    var datPath = undefined
+    var datPath
     if (opts.key === '.' || opts.key === undefined) {
       datPath = path.resolve('dat.json')
     } else {

--- a/src/commands/clone.js
+++ b/src/commands/clone.js
@@ -31,6 +31,7 @@ module.exports = {
 
 function clone (opts) {
   var fs = require('fs')
+  var path = require('path')
   var rimraf = require('rimraf')
   var Dat = require('dat-node')
   var linkResolve = require('dat-link-resolve')
@@ -42,7 +43,6 @@ function clone (opts) {
   var parseArgs = require('../parse-args')
   var debug = require('debug')('dat')
   var parsed = parseArgs(opts)
-  var path = require('path')
   var isDatLink = require('dat-is-link')
 
   opts.key = parsed.key || opts._[0] // pass other links to resolver
@@ -58,7 +58,7 @@ function clone (opts) {
         datPath = path.resolve('dat.json')
         opts.dir = opts.key
       } else if (fs.existsSync(path.resolve(opts.key + '/dat.json'))) {
-        datPath = path.resolve(opts.key + 'dat.son')
+        datPath = path.resolve(opts.key + 'dat.json')
       } else if (path.basename(opts.key) === 'dat.json') {
         datPath = path.resolve(opts.key)
       }

--- a/src/commands/clone.js
+++ b/src/commands/clone.js
@@ -42,10 +42,14 @@ function clone (opts) {
   var onExit = require('../lib/exit')
   var parseArgs = require('../parse-args')
   var debug = require('debug')('dat')
-  var parsed = parseArgs(opts)
 
+  var parsed = parseArgs(opts)
   opts.key = parsed.key || opts._[0] // pass other links to resolver
   opts.dir = parsed.dir
+  opts.showKey = opts['show-key'] // using abbr in option makes printed help confusing
+  opts.sparse = opts.empty
+
+  debug('clone()')
 
   // variables needed to check if opts.key is on system and leads to a dat.json file.
   var datPath = opts.key
@@ -69,10 +73,6 @@ function clone (opts) {
   // if the datPath is valid parse it for a url key and set opts.key to the parsed url key.
   if (fs.existsSync(datPath)) opts.key = JSON.parse(fs.readFileSync(datPath, 'utf8')).url
 
-  opts.showKey = opts['show-key'] // using abbr in option makes printed help confusing
-  opts.sparse = opts.empty
-
-  debug('clone()')
   debug(Object.assign({}, opts, {key: '<private>', _: null})) // don't show key
 
   var neat = neatLog(archiveUI, { logspeed: opts.logspeed, quiet: opts.quiet })

--- a/src/commands/clone.js
+++ b/src/commands/clone.js
@@ -47,9 +47,6 @@ function clone (opts) {
   opts.key = parsed.key || opts._[0] // pass other links to resolver
   opts.dir = parsed.dir
 
-  // corrects parse-args.js default output for when no second argument for output directory is provided.
-  if (parsed.keyCloneSwitch) opts.dir = path.resolve('.')
-
   // variables needed to check if opts.key is on system and leads to a dat.json file.
   var datPath = opts.key
   var onSystem = fs.existsSync(datPath)

--- a/src/commands/clone.js
+++ b/src/commands/clone.js
@@ -45,20 +45,20 @@ function clone (opts) {
   var path = require('path')
 
   opts.key = parsed.key || opts._[0] // pass other links to resolver
+  opts.dir = parsed.dir
 
   // Resolves dat.json path and parses dat url from it.
-  // Null doesn't work yet. May have something to do with ../parse-args. Will submit issue.
-  if (opts.key === '.' || opts.key === null || path.basename(opts.key) === 'dat.json') {
-    var datPath = null
-    if (opts.key === '.' || opts.key === null) {
+  if (opts.key === '.' || opts.key === undefined || path.basename(opts.key) === 'dat.json') {
+    var datPath = undefined
+    if (opts.key === '.' || opts.key === undefined) {
       datPath = path.resolve('dat.json')
     } else {
       datPath = path.resolve(opts.key)
     }
+    opts.dir = opts.dir || path.resolve('.') // if needed changes output directory from undefined to current.
     opts.key = JSON.parse(fs.readFileSync(datPath, 'utf8')).url
   }
 
-  opts.dir = parsed.dir
   opts.showKey = opts['show-key'] // using abbr in option makes printed help confusing
   opts.sparse = opts.empty
 

--- a/src/commands/clone.js
+++ b/src/commands/clone.js
@@ -51,27 +51,14 @@ function clone (opts) {
 
   debug('clone()')
 
-  // variables needed to check if opts.key is on system and leads to a dat.json file.
-  var datPath = opts.key
-  var onSystem = fs.existsSync(datPath)
-  var isDir = false
-  var isDatJson = false
-
-  // if the file or directory is on system check to see whether the path is to a dat.json file or directory.
-  if (onSystem) {
-    isDir = fs.lstatSync(datPath).isDirectory()
-    isDatJson = (fs.lstatSync(datPath).isFile() && (path.basename(datPath) === 'dat.json'))
+  // cmd: dat /path/to/dat.json (opts.key is path to dat.json)
+  if (fs.existsSync(opts.key)) {
+    try {
+      opts.key = getDatJsonKey()
+    } catch (e) {
+      debug('error reading dat.json key', e)
+    }
   }
-
-  // if file is a dat.json resolve absolute path. else if directory try to resolve path to dat.json.
-  if (isDatJson) {
-    datPath = path.resolve(datPath)
-  } else if (isDir) {
-    datPath = path.join(datPath, 'dat.json')
-  }
-
-  // if the datPath is valid parse it for a url key and set opts.key to the parsed url key.
-  if (fs.existsSync(datPath)) opts.key = JSON.parse(fs.readFileSync(datPath, 'utf8')).url
 
   debug(Object.assign({}, opts, {key: '<private>', _: null})) // don't show key
 
@@ -132,4 +119,22 @@ function clone (opts) {
       })
     }
   })
+
+  function getDatJsonKey () {
+     // variables needed to check if opts.key is on system and leads to a dat.json file.
+    var datPath = opts.key
+    var stat = fs.lstatSync(datPath)
+    var isDir = stat.isDirectory()
+    var isDatJson = (fs.lstatSync(datPath).isFile() && (path.basename(datPath) === 'dat.json'))
+
+    // if file is a dat.json resolve absolute path. else if directory try to resolve path to dat.json.
+    if (isDatJson) {
+      datPath = path.resolve(datPath)
+    } else if (isDir) {
+      datPath = path.join(datPath, 'dat.json')
+    }
+
+    // if the datPath is valid parse it for a url key and set opts.key to the parsed url key.
+    return JSON.parse(fs.readFileSync(datPath, 'utf8')).url
+  }
 }

--- a/src/parse-args.js
+++ b/src/parse-args.js
@@ -40,6 +40,7 @@ module.exports = function (opts) {
   try {
     if (fs.statSync(opts._[0]).isDirectory()) {
       parsed.dir = opts._[0]
+      parsed.keyToDirSwitch = true // switch for clone dat.json resolution.
     }
   } catch (err) {
     if (err && !err.name === 'ENOENT') {

--- a/src/parse-args.js
+++ b/src/parse-args.js
@@ -39,10 +39,11 @@ module.exports = function (opts) {
   }
 
   try {
-    if (fs.statSync(opts._[0]).isDirectory() && opts._.length !== 2) {
-      parsed.dir = opts._[0]
-    } else if (fs.statSync(opts._[0]).isFile() && opts._.length !== 2) {
+    var stat = fs.statSync(opts._[0])
+    if (stat.isFile()) {
       parsed.dir = path.resolve(path.dirname(opts._[0]))
+    } else {
+      parsed.dir = opts._[0]
     }
   } catch (err) {
     if (err && !err.name === 'ENOENT') {

--- a/src/parse-args.js
+++ b/src/parse-args.js
@@ -40,7 +40,9 @@ module.exports = function (opts) {
   try {
     if (fs.statSync(opts._[0]).isDirectory()) {
       parsed.dir = opts._[0]
-      parsed.keyToDirSwitch = true // switch for clone dat.json resolution.
+      parsed.keyCloneSwitch = true // switch for clone dat.json resolution.
+    } else if (fs.statSync(opts._[0]).isFile() && opts._.length !== 2) {
+      parsed.keyCloneSwitch = true
     }
   } catch (err) {
     if (err && !err.name === 'ENOENT') {

--- a/src/parse-args.js
+++ b/src/parse-args.js
@@ -1,4 +1,5 @@
 var fs = require('fs')
+var path = require('path')
 var encoding = require('dat-encoding')
 
 module.exports = function (opts) {
@@ -40,9 +41,8 @@ module.exports = function (opts) {
   try {
     if (fs.statSync(opts._[0]).isDirectory()) {
       parsed.dir = opts._[0]
-      parsed.keyCloneSwitch = true // switch for clone dat.json resolution.
     } else if (fs.statSync(opts._[0]).isFile() && opts._.length !== 2) {
-      parsed.keyCloneSwitch = true
+      parsed.dir = path.resolve(path.dirname(opts._[0]))
     }
   } catch (err) {
     if (err && !err.name === 'ENOENT') {

--- a/src/parse-args.js
+++ b/src/parse-args.js
@@ -39,7 +39,7 @@ module.exports = function (opts) {
   }
 
   try {
-    if (fs.statSync(opts._[0]).isDirectory()) {
+    if (fs.statSync(opts._[0]).isDirectory() && opts._.length !== 2) {
       parsed.dir = opts._[0]
     } else if (fs.statSync(opts._[0]).isFile() && opts._.length !== 2) {
       parsed.dir = path.resolve(path.dirname(opts._[0]))


### PR DESCRIPTION
Pull request #845 was accidentally merged and had to be reverted. 

I've added a `dat.json` url parser to the clone command as described in #639. `dat clone /path/to/key`, `dat clone /path/to/dat.json`, `dat clone /path/to/key ./dir`and `dat clone ./path/to/dat.json ./dir` should work as expected and clone into the target directory. If the target directory isn't specified the target directory defaults to `.`.

This will also likely solve issue #792.
 
