### PR TITLE
Fix typos/grammar in readme, update links to use HTTPS, dat vs. Dat.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Secure, distributed, fast.
 
 Have questions? Join our chat via IRC or Gitter:
 
-[![#dat IRC channel on freenode](https://img.shields.io/badge/irc%20channel-%23dat%20on%20freenode-blue.svg)](http://webchat.freenode.net/?channels=dat)
+[![#dat IRC channel on freenode](https://img.shields.io/badge/irc%20channel-%23dat%20on%20freenode-blue.svg)](https://webchat.freenode.net/?channels=dat)
 [![datproject/discussions](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/datproject/discussions?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 ### Table of Contents
@@ -28,23 +28,23 @@ Share, backup, and publish your filesystem. You can turn any folder on your comp
 
 * Track your files with automatic version history.
 * Share files with others over a secure peer to peer network.
-* Automate live backups to external hds or remote servers.
+* Automate live backups to external HDs or remote servers.
 * Publish and share files with built in HTTP server.
 
 Dat allows you to focus on the fun work without worrying about moving files around. **Secure**, **distributed**, **fast**.
 
-The [Dat Project](http://datproject.org) is the home to open source data sharing applications led by [Code for Science & Society](http://codeforscience.org), a nonprofit.
+The [Dat Project](https://datproject.org) is the home to open source data sharing applications led by [Code for Science & Society](https://codeforscience.org), a nonprofit.
 
-* Documentation: [docs.datproject.org](http://docs.datproject.org)
-* Dat Protocol: [datprotocol.com](http://www.datprotocol.com)
+* Documentation: [docs.datproject.org](https://docs.datproject.org)
+* Dat Protocol: [datprotocol.com](https://www.datprotocol.com)
 * [Dat white paper](https://github.com/datproject/docs/blob/master/papers/dat-paper.pdf)
 
 ##### Other Applications
 
 Rather not use the command line? Check out these options:
 
-* [Dat Desktop](https://datproject.org/install#desktop) - A desktop app to manage multiple Dats on your desktop machine.
-* [Beaker Browser](http://beakerbrowser.com) - An experimental p2p browser with built-in support for the Dat protocol.
+* [Dat Desktop](https://datproject.org/install#desktop) - A desktop app to manage multiple dats on your desktop machine.
+* [Beaker Browser](https://beakerbrowser.com) - An experimental p2p browser with built-in support for the Dat protocol.
 
 ## dat command line
 
@@ -55,14 +55,14 @@ Mac/Linux      | Windows      | Version
 [![Travis](https://travis-ci.org/datproject/dat.svg?branch=master)](https://travis-ci.org/datproject/dat) | [![Build status](https://ci.appveyor.com/api/projects/status/github/datproject/dat?branch=master&svg=true)](https://ci.appveyor.com/project/joehand/dat/branch/master) | [![NPM version](https://img.shields.io/npm/v/dat.svg)](https://npmjs.org/package/dat)
 
 Have questions or need some guidance?
-You can chat with us in IRC on [#dat](http://webchat.freenode.net/?channels=dat) or [Gitter](https://gitter.im/datproject/discussions?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)!
+You can chat with us in IRC on [#dat](https://webchat.freenode.net/?channels=dat) or [Gitter](https://gitter.im/datproject/discussions?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)!
 
 ## Installation
 
-Dat can be used as a command line tool or as javascript library:
+Dat can be used as a command line tool or a javascript library:
 
 * `npm install -g dat` - Install `dat` globally to use in the command line.
-* [require('dat')](http://github.com/datproject/dat-node) - dat-node, a library for downloading and sharing Dat archives in javascript apps.
+* [require('dat')](https://github.com/datproject/dat-node) - dat-node, a library for downloading and sharing dat archives in javascript apps.
 
 ### Installing via npm
 
@@ -85,9 +85,9 @@ Once you have `npm` ready, install `dat` from npm with the `--global, -g` option
 
 ### JS Library
 
-Add Dat to your `package.json`, `npm install dat --save`. Dat exports the [dat-node](http://github.com/datproject/dat-node) API via `require('dat')`. Use it in your javascript applications! Dat Desktop and dat command line both use dat-node to share and download dats.
+Add Dat to your `package.json`, `npm install dat --save`. Dat exports the [dat-node](https://github.com/datproject/dat-node) API via `require('dat')`. Use it in your javascript applications! Dat Desktop and Dat command line both use dat-node to share and download dats.
 
-Full API documentation is available in the dat-node repository on Github.
+Full API documentation is available in the [dat-node](https://github.com/datproject/dat-node) repository on Github.
 
 ## Getting started
 
@@ -95,27 +95,27 @@ We have Dat installed, let's use it!
 
 Dat's unique design works wherever you store your data. You can create a new dat from any folder on your computer.
 
-A dat is some files from your computer and a `.dat` folder. Each dat has unique `dat://` link. With your dat link, other users can download your files and live sync any updates.
+A dat is some files from your computer and a `.dat` folder. Each dat has a unique `dat://` link. With your dat link, other users can download your files and live sync any updates.
 
 ### Sharing Data
 
 You can start sharing your files with a single command. Unlike `git`, you do not have to initialize a repository first, `dat share` will do that for you:
 
 ```
-dat share <dir>
+dat share <folder>
 ```
 
-Use `dat share` to create a dat and sync your files from your computer to other users. Dat scans your files inside `<dir>`, creating metadata in `<dir>/.dat`. Dat stores the public link, version history, and file information inside the dat folder.
+Use `dat share` to create a dat and sync your files from your computer to other users. Dat scans your files inside `<folder>`, creating metadata in `<folder>/.dat`. Dat stores the public link, version history, and file information inside the dat folder.
 
 ![share](https://raw.githubusercontent.com/datproject/docs/master/assets/cli-share.gif)
 
 ### Downloading Data
 
 ```
-dat clone dat://<link> <download-dir>
+dat clone dat://<link> <download-folder>
 ```
 
-Use `dat clone` to download files from a remote computers sharing files with Dat. This will download the files from `dat://<link>` to your `<download-dir>`. The download exits after it completes but you can continue to update the files later after the clone is done. Use `dat pull` to update new files or `dat sync` to live sync changes.
+Use `dat clone` to download files from a remote computer sharing files with Dat. This will download the files from `dat://<link>` to your `<download-folder>`. The download exits after it completes but you can continue to update the files later after the clone is done. Use `dat pull` to update new files or `dat sync` to live sync changes.
 
 ![clone](https://raw.githubusercontent.com/datproject/docs/master/assets/cli-clone.gif)
 
@@ -125,7 +125,7 @@ Try out `dat clone` with the link above to read more about the protocol!
 
 A few other highlights. Run `dat help` to see the full usage guide.
 
-* `dat create` - Create a empty dat and dat.json file.
+* `dat create` - Create an empty dat and `dat.json` file.
 * `dat doctor` - Dat network doctor! The doctor tries to connect to a public peer. The doctor also creates a key to test direct connections.
 * `dat log ~/data/dat-folder/` or `dat log dat://<key>` - view the history and metadata information for a dat.
 
@@ -135,9 +135,9 @@ To get started using Dat, you can try downloading a dat and then sharing a dat o
 
 #### Download Demo
 
-We made a demo folder we made just for this exercise. Inside the demo folder is a `dat.json` file and a gif. We shared these files via Dat and now you can download them with our dat key!
+We made a demo folder just for this exercise. Inside the demo folder is a `dat.json` file and a gif. We shared these files via Dat and now you can download them with our dat key!
 
-Similar to git, you do download somebody's dat by running `dat clone <link>`. You can also specify the directory:
+Similar to git, you can download somebody's dat by running `dat clone <link>`. You can also specify the directory:
 
 ```
 ❯ dat clone dat://778f8d955175c92e4ced5e4f5563f69bfec0c86cc6f670352c457943666fe639 ~/Downloads/dat-demo
@@ -151,9 +151,9 @@ dat sync complete.
 Version 4
 ```
 
-This will download our demo files to the `~/downloads/dat-demo` folder. These files are being shared by a server over Dat (to ensure high availability) but you may connect to any number of users also hosting the content.
+This will download our demo files to the `~/Downloads/dat-demo` folder. These files are being shared by a server over Dat (to ensure high availability) but you may connect to any number of users also hosting the content.
 
-You can also also view the files online: [datproject.org/778f8d955175c92e4ced5e4f5563f69bfec0c86cc6f670352c457943666fe639](https://datproject.org/778f8d955175c92e4ced5e4f5563f69bfec0c86cc6f670352c457943666fe639/). datproject.org can download files over Dat and display them on http as long as someone is hosting it. The website temporarily caches data for any visited links (do not view your dat on datproject.org if you do not want us caching your data).
+You can also also view the files online: [datproject.org/778f8d955175c92e4ced5e4f5563f69bfec0c86cc6f670352c457943666fe639](https://datproject.org/778f8d955175c92e4ced5e4f5563f69bfec0c86cc6f670352c457943666fe639/). datproject.org can download files over Dat and display them on HTTP as long as someone is hosting it. The website temporarily caches data for any visited links (do not view your dat on datproject.org if you do not want us to cache your data).
 
 #### Sharing Demo
 
@@ -178,7 +178,7 @@ You can also try viewing your files online. Go to [datproject.org](https://datpr
 
 #### Bonus HTTP Demo
 
-Dat makes it really easy to live files on a http server. This is a cool demo because we can also see how version history works! Serve dat files on http with the `--http` option. For example, `dat sync --http`, serves your files to a http website with live reloading and version history! This even works dats your are downloading (add the `--sparse` option to only download files you select via http). The default http port is 8080.
+Dat makes it really easy to share live files on a HTTP server. This is a cool demo because we can also see how version history works! Serve dat files on HTTP with the `--http` option. For example, `dat sync --http`, serves your files to a HTTP website with live reloading and version history! This even works for dats you're downloading (add the `--sparse` option to only download files you select via HTTP). The default HTTP port is 8080.
 
 *Hint: Use `localhost:8080/?version=10` to view a specific version.*
 
@@ -186,10 +186,10 @@ Get started using Dat today with the `share` and `clone` commands or read below 
 
 ## Usage
 
-The first time you run a command, a `.dat` folder to store the Dat metadata.
-Once a Dat is created, you can run all the commands inside that folder, similar to git.
+The first time you run a command, a `.dat` folder is created to store the dat metadata.
+Once a dat is created, you can run all the commands inside that folder, similar to git.
 
-Dat keep secret keys in the `~/.dat/secret_keys` folder. These are required to write to any dats you create.
+Dat keeps secret keys in the `~/.dat/secret_keys` folder. These are required to write to any dats you create.
 
 ### Sharing
 
@@ -214,7 +214,7 @@ ADD: data/expn_cd.csv (403 MB / 920 MB)
 dat create [<folder>]
 ```
 
-The create command prompts you to make a dat.json file and creates a new dat. Import the files with sync or share.
+The create command prompts you to make a `dat.json` file and creates a new dat. Import the files with sync or share.
 
 
 #### Syncing to Network
@@ -223,38 +223,38 @@ The create command prompts you to make a dat.json file and creates a new dat. Im
 dat sync [<folder>] [--no-import] [--no-watch]
 ```
 
-Start sharing your Dat Archive over the network.
-Sync will import new or updated files since you ran `create` or `sync` last.
-Sync watched files for changes and imports updated files.
+Start sharing your dat archive over the network.
+Sync will import new or updated files since you last ran `create` or `sync`.
+Sync watches files for changes and imports updated files.
 
 * Use `--no-import` to not import any new or updated files.
 * Use `--no-watch` to not watch directory for changes. `--import` must be true for `--watch` to work.
 
 #### Ignoring Files
 
-By default, dat will ignore any files in a `.datignore` file, similar to git. Each file should separated by a newline. Dat also ignores all hidden folders and files.
+By default, Dat will ignore any files in a `.datignore` file, similar to git. Each file should be separated by a newline. Dat also ignores all hidden folders and files.
 
 Dat uses [dat-ignore](https://github.com/joehand/dat-ignore) to decide if a file should be ignored.
 
 #### Selecting Files
 
-By default, dat will download all files. If you want to only download a subset, you can create a `.datdownload` file which downloads only the files and folders specified. Each should be separated by a newline.
+By default, Dat will download all files. If you want to only download a subset, you can create a `.datdownload` file which downloads only the files and folders specified. Each should be separated by a newline.
 
 
 ### Downloading
 
-Start downloading by running the `clone` command. This creates a folder, download the content and metadata, and a `.dat` folder inside. Once you started the download, you can resume using `clone` or the other download commands.
+Start downloading by running the `clone` command. This creates a folder, downloads the content and metadata, and a `.dat` folder inside. Once you started the download, you can resume using `clone` or the other download commands.
 
 ```
-dat clone <dat-link> [<folder>] [--temp]
+dat clone <link> [<folder>] [--temp]
 ```
 
-Clone a remote Dat Archive to a local folder.
-This will create a folder with the key name is no folder is specified.
+Clone a remote dat archive to a local folder.
+This will create a folder with the key name if no folder is specified.
 
 #### Downloading via `dat.json` key
 
-You can use a `dat.json` file to clone also. This is useful when combining dat and git, for example. To clone a dat you can specify the path to a folder containing a `dat.json`:
+You can use a `dat.json` file to clone also. This is useful when combining Dat and git, for example. To clone a dat you can specify the path to a folder containing a `dat.json`:
 
 ```
 git clone git@github.com:joehand/dat-clone-sparse-test.git
@@ -265,13 +265,13 @@ This will download the dat specified in the `dat.json` file.
 
 #### Updating Downloaded Archives
 
-Once a Dat is clone, you can run either `dat pull` or `dat sync` in the folder to update the archive.
+Once a dat is clone, you can run either `dat pull` or `dat sync` in the folder to update the archive.
 
 ```
 dat pull [<folder>]
 ```
 
-Update a cloned Dat Archive to latest files and exit.
+Update a cloned dat archive with the latest files and exit.
 
 ```
 dat sync [<folder>]
@@ -281,14 +281,14 @@ Download latest files and keep connection open to continue updating as remote so
 
 ### Shortcut commands
 
-* `dat <link> {dir}` will run `dat clone` for new dats or resume the exiting dat in `dir`
-* `dat {dir}` is the same as running `dat sync {dir}`
+* `dat <link> <folder>` will run `dat clone` for new dats or resume the existing dat in `<folder>`
+* `dat <folder>` is the same as running `dat sync <folder>`
 
 ### Dat Registry and Authentication
 
-As part of our [Knight Foundation grant](https://datproject.org/blog/2016-02-01-announcing-publicbits), we are building a registry for Dat archives.
-We will be running a Dat registry at datproject.org, but anyone will be able to create their own.
-Once registered, you will be able to publish Dat archives from our registry.
+As part of our [Knight Foundation grant](https://datproject.org/blog/2016-02-01-announcing-publicbits), we are building a registry for dat archives.
+We will be running a dat registry at datproject.org, but anyone will be able to create their own.
+Once registered, you will be able to publish dat archives from our registry.
 Anyone can clone archives published to a registry without registration:
 
 ```
@@ -297,7 +297,7 @@ dat clone datproject.org/jhand/cli-demo
 
 #### Auth (experimental)
 
-You can also use the `dat` command line to register and publish to Dat registries. Dat plans to support any registry. Currently, `datproject.org` is the only available and the default.
+You can also use the `dat` command line to register and publish to dat registries. Dat plans to support any registry. Currently, `datproject.org` is the only one available and the default.
 
 To register and login you can use the following commands:
 
@@ -307,7 +307,7 @@ dat login
 dat whoami
 ```
 
-Once you are logged in to a registry. You can publish a Dat archive:
+Once you are logged in to a registry, you can publish a dat archive:
 
 ```
 cd my-data
@@ -318,14 +318,14 @@ dat publish --name my-dataset
 All registry requests take the `<registry>` option if you'd like to publish to a different registry than datproject.org.
 You can deploy your own compatible [registry server](https://github.com/datproject/datproject.org) if you'd rather use your own service.
 
-### Key Management & Moving Dats
+### Key Management & Moving dats
 
 `dat keys` provides a few commands to help you move or backup your dats.
 
 Writing to a dat requires the secret key, stored in the `~/.dat` folder. You can export and import these keys between dats. First, clone your dat to the new location:
 
 * (original) `dat share`
-* (duplicate) `dat clone <key>`
+* (duplicate) `dat clone <link>`
 
 Then transfer the secret key:
 
@@ -349,7 +349,7 @@ Check your Dat version:
 dat -v
 ```
 
-You should see the Dat semantic version printed, e.g. 13.1.2.
+You should see the Dat semantic version printed, e.g. `13.1.2`.
 
 ### Installation Issues
 
@@ -366,16 +366,16 @@ npm -v
 
 #### Global Install
 
-The `-g` option installs Dat globally allowing you to run it as a command.
+The `-g` option installs Dat globally, allowing you to run it as a command.
 Make sure you installed with that option.
 
 * If you receive an `EACCES` error, read [this guide](https://docs.npmjs.com/getting-started/fixing-npm-permissions) on fixing npm permissions.
-* If you receive an `EACCES` error, you may also install dat with sudo: `sudo npm install -g dat`.
+* If you receive an `EACCES` error, you may also install Dat with sudo: `sudo npm install -g dat`.
 * Have other installation issues? Let us know, you can [open an issue](https://github.com/datproject/dat/issues/new) or ask us in our [chat room](https://gitter.im/datproject/discussions).
 
 ### Debugging Output
 
-If you are having trouble with a specific command, run with the debug environment variable set to `dat` (and optionally also `dat-node`). =
+If you are having trouble with a specific command, run with the debug environment variable set to `dat` (and optionally also `dat-node`).
 This will help us debug any issues:
 
 ```
@@ -385,14 +385,14 @@ DEBUG=dat,dat-node dat clone dat://<link> dir
 ### Networking Issues
 
 Networking capabilities vary widely with each computer, network, and configuration.
-Whenever you run a Dat there are several steps to share or download files with peers:
+Whenever you run Dat there are several steps to share or download files with peers:
 
 1. Discovering Peers
 2. Connecting to Peers
 3. Sending & Receiving Data
 
 With successful use, Dat will show `Connected to 1 peer` after connection.
-If you never see a peer connected your network may be restricting discovery or connection.
+If you never see a peer connected, your network may be restricting discovery or connection.
 Please try using the `dat --doctor` command (see below) between the two computers not connecting. This will help troubleshoot the networks.
 
 * Dat may [have issues](https://github.com/datproject/dat/issues/503) connecting if you are using iptables.
@@ -402,7 +402,7 @@ Please try using the `dat --doctor` command (see below) between the two computer
 We've included a tool to identify network issues with Dat, the Dat doctor.
 The Dat doctor will run two tests:
 
-1. Attempt to connect to a server running a Dat peer.
+1. Attempt to connect to a public server running a Dat peer.
 2. Attempt a direct connection between two peers. You will need to run the command on both the computers you are trying to share data between.
 
 Start the doctor by running:
@@ -446,7 +446,7 @@ npm link
 ```
 
 This should add a `dat` command line command to your PATH.
-Now you can run the dat command to try it out.
+Now you can run the `dat` command to try it out.
 
 The contribution guide also has more tips on our [development workflow](https://github.com/datproject/dat/blob/master/CONTRIBUTING.md#development-workflow).
 

--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@ Dat is the distributed data sharing tool.
 Share files with version control, back up data to servers, browse remote files on demand, and automate long-term data preservation.
 Secure, distributed, fast.
 
-[<img src="https://datproject.github.io/design/downloads/dat-data-logo.png" align="right" width="140">](https://datproject.org)
+[<img src="https://datproject.github.io/design/downloads/dat-data-logo.png" align="right" width="140">][Dat Project]
 
 Have questions? Join our chat via IRC or Gitter:
 
-[![#dat IRC channel on freenode](https://img.shields.io/badge/irc%20channel-%23dat%20on%20freenode-blue.svg)](https://webchat.freenode.net/?channels=dat)
-[![datproject/discussions](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/datproject/discussions?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![#dat IRC channel on freenode][irc-badge]][irc-channel]
+[![datproject/discussions][gitter-badge]][gitter-chat]
 
 ### Table of Contents
 
@@ -33,18 +33,18 @@ Share, backup, and publish your filesystem. You can turn any folder on your comp
 
 Dat allows you to focus on the fun work without worrying about moving files around. **Secure**, **distributed**, **fast**.
 
-The [Dat Project](https://datproject.org) is the home to open source data sharing applications led by [Code for Science & Society](https://codeforscience.org), a nonprofit.
+The [Dat Project] is the home to open source data sharing applications led by [Code for Science & Society], a nonprofit.
 
 * Documentation: [docs.datproject.org](https://docs.datproject.org)
 * Dat Protocol: [datprotocol.com](https://www.datprotocol.com)
-* [Dat white paper](https://github.com/datproject/docs/blob/master/papers/dat-paper.pdf)
+* [Dat white paper]
 
 ##### Other Applications
 
 Rather not use the command line? Check out these options:
 
-* [Dat Desktop](https://datproject.org/install#desktop) - A desktop app to manage multiple dats on your desktop machine.
-* [Beaker Browser](https://beakerbrowser.com) - An experimental p2p browser with built-in support for the Dat protocol.
+* [Dat Desktop] - A desktop app to manage multiple dats on your desktop machine.
+* [Beaker Browser] - An experimental p2p browser with built-in support for the Dat protocol.
 
 ## dat command line
 
@@ -52,17 +52,17 @@ Share, download, and backup files with the command line! Automatically sync chan
 
 Mac/Linux      | Windows      | Version
 -------------- | ------------ | ------------
-[![Travis](https://travis-ci.org/datproject/dat.svg?branch=master)](https://travis-ci.org/datproject/dat) | [![Build status](https://ci.appveyor.com/api/projects/status/github/datproject/dat?branch=master&svg=true)](https://ci.appveyor.com/project/joehand/dat/branch/master) | [![NPM version](https://img.shields.io/npm/v/dat.svg)](https://npmjs.org/package/dat)
+[![Travis][travis-badge]][travis-build] | [![Build status][appveyor-badge]][appveyor-build] | [![NPM version][npm-badge]][npm-package]
 
 Have questions or need some guidance?
-You can chat with us in IRC on [#dat](https://webchat.freenode.net/?channels=dat) or [Gitter](https://gitter.im/datproject/discussions?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)!
+You can chat with us in IRC on [#dat][irc-channel] or [Gitter][gitter-chat]!
 
 ## Installation
 
 Dat can be used as a command line tool or a javascript library:
 
 * `npm install -g dat` - Install `dat` globally to use in the command line.
-* [require('dat')](https://github.com/datproject/dat-node) - dat-node, a library for downloading and sharing dat archives in javascript apps.
+* [require('dat')][dat-node] - dat-node, a library for downloading and sharing dat archives in javascript apps.
 
 ### Installing via npm
 
@@ -78,16 +78,16 @@ Once `npm install` finishes, you should be able to run the `dat` command. If not
 
 #### Prerequisites
 
-* **Node**: You'll need to [install Node](https://nodejs.org/en/download/) before installing Dat. Dat needs `node` version 4 or above and `npm` installed. You can run `node -v` to check your version.
+* **Node**: You'll need to [install Node JS][install-node] before installing Dat. Dat needs `node` version 4 or above and `npm` installed. You can run `node -v` to check your version.
 * **npm**: `npm` is installed with node. You can run `npm -v` to make sure it is installed.
 
 Once you have `npm` ready, install `dat` from npm with the `--global, -g` option, `npm install -g dat`.
 
 ### JS Library
 
-Add Dat to your `package.json`, `npm install dat --save`. Dat exports the [dat-node](https://github.com/datproject/dat-node) API via `require('dat')`. Use it in your javascript applications! Dat Desktop and Dat command line both use dat-node to share and download dats.
+Add Dat to your `package.json`, `npm install dat --save`. Dat exports the [dat-node] API via `require('dat')`. Use it in your javascript applications! Dat Desktop and Dat command line both use dat-node to share and download dats.
 
-Full API documentation is available in the [dat-node](https://github.com/datproject/dat-node) repository on Github.
+Full API documentation is available in the [dat-node] repository on Github.
 
 ## Getting started
 
@@ -107,17 +107,17 @@ dat share <dir>
 
 Use `dat share` to create a dat and sync your files from your computer to other users. Dat scans your files inside `<dir>`, creating metadata in `<dir>/.dat`. Dat stores the public link, version history, and file information inside the dat folder.
 
-![share](https://raw.githubusercontent.com/datproject/docs/master/assets/cli-share.gif)
+![share-gif]
 
 ### Downloading Data
 
 ```
-dat clone dat://<link> <download-folder>
+dat clone dat://<link> <download-dir>
 ```
 
-Use `dat clone` to download files from a remote computer sharing files with Dat. This will download the files from `dat://<link>` to your `<download-folder>`. The download exits after it completes but you can continue to update the files later after the clone is done. Use `dat pull` to update new files or `dat sync` to live sync changes.
+Use `dat clone` to download files from a remote computer sharing files with Dat. This will download the files from `dat://<link>` to your `<download-dir>`. The download exits after it completes but you can continue to update the files later after the clone is done. Use `dat pull` to update new files or `dat sync` to live sync changes.
 
-![clone](https://raw.githubusercontent.com/datproject/docs/master/assets/cli-clone.gif)
+![clone-gif]
 
 Try out `dat clone` with the link above to read more about the protocol!
 
@@ -234,7 +234,7 @@ Sync watches files for changes and imports updated files.
 
 By default, Dat will ignore any files in a `.datignore` file, similar to git. Each file should be separated by a newline. Dat also ignores all hidden folders and files.
 
-Dat uses [dat-ignore](https://github.com/joehand/dat-ignore) to decide if a file should be ignored.
+Dat uses [dat-ignore] to decide if a file should be ignored.
 
 #### Selecting Files
 
@@ -286,7 +286,7 @@ Download latest files and keep connection open to continue updating as remote so
 
 ### Dat Registry and Authentication
 
-As part of our [Knight Foundation grant](https://datproject.org/blog/2016-02-01-announcing-publicbits), we are building a registry for dat archives.
+As part of our [Knight Foundation grant], we are building a registry for dat archives.
 We will be running a dat registry at datproject.org, but anyone will be able to create their own.
 Once registered, you will be able to publish dat archives from our registry.
 Anyone can clone archives published to a registry without registration:
@@ -316,7 +316,7 @@ dat publish --name my-dataset
 ```
 
 All registry requests take the `<registry>` option if you'd like to publish to a different registry than datproject.org.
-You can deploy your own compatible [registry server](https://github.com/datproject/datproject.org) if you'd rather use your own service.
+You can deploy your own compatible [registry server] if you'd rather use your own service.
 
 ### Key Management & Moving dats
 
@@ -335,7 +335,7 @@ Then transfer the secret key:
 ## Troubleshooting
 
 We've provided some troubleshooting tips based on issues users have seen.
-Please [open an issue](https://github.com/datproject/dat/issues/new) or ask us in our [chat room](https://gitter.im/datproject/discussions) if you need help troubleshooting and it is not covered here.
+Please [open an issue][new-issue] or ask us in our [chat room][gitter-chat] if you need help troubleshooting and it is not covered here.
 
 If you have trouble sharing/downloading in a directory with a `.dat` folder, try deleting it and running the command again.
 
@@ -355,7 +355,7 @@ You should see the Dat semantic version printed, e.g. `13.1.2`.
 
 #### Node & npm
 
-To use the Dat command line tool you will need to have [node and npm installed](https://docs.npmjs.com/getting-started/installing-node).
+To use the Dat command line tool you will need to have [node and npm installed][install-node-npm].
 Make sure those are installed correctly before installing Dat.
 You can check the version of each:
 
@@ -369,9 +369,9 @@ npm -v
 The `-g` option installs Dat globally, allowing you to run it as a command.
 Make sure you installed with that option.
 
-* If you receive an `EACCES` error, read [this guide](https://docs.npmjs.com/getting-started/fixing-npm-permissions) on fixing npm permissions.
+* If you receive an `EACCES` error, read [this guide][fixing-npm-permissions] on fixing npm permissions.
 * If you receive an `EACCES` error, you may also install Dat with sudo: `sudo npm install -g dat`.
-* Have other installation issues? Let us know, you can [open an issue](https://github.com/datproject/dat/issues/new) or ask us in our [chat room](https://gitter.im/datproject/discussions).
+* Have other installation issues? Let us know, you can [open an issue][new-issue] or ask us in our [chat room][gitter-chat].
 
 ### Debugging Output
 
@@ -395,7 +395,7 @@ With successful use, Dat will show `Connected to 1 peer` after connection.
 If you never see a peer connected, your network may be restricting discovery or connection.
 Please try using the `dat --doctor` command (see below) between the two computers not connecting. This will help troubleshoot the networks.
 
-* Dat may [have issues](https://github.com/datproject/dat/issues/503) connecting if you are using iptables.
+* Dat may [have issues][dat#503] connecting if you are using iptables.
 
 #### Dat Doctor
 
@@ -428,13 +428,13 @@ Dat('/data', function (err, dat) {
 })
 ```
 
-**[Read more](https://github.com/datproject/dat-node) about the JS usage provided via `dat-node`.**
+**[Read more][dat-node] about the JS usage provided via `dat-node`.**
 
 ## For Developers
 
-Please see [guidelines on contributing](https://github.com/datproject/dat/blob/master/CONTRIBUTING.md) before submitting an issue or PR.
+Please see [guidelines on contributing] before submitting an issue or PR.
 
-This command line library uses [dat-node](https://github.com/datproject/dat-node) to create and manage the archives and networking.
+This command line library uses [dat-node] to create and manage the archives and networking.
 If you'd like to build your own Dat application that is compatible with this command line tool, we suggest using dat-node.
 
 ### Installing from source
@@ -448,7 +448,7 @@ npm link
 This should add a `dat` command line command to your PATH.
 Now you can run the `dat` command to try it out.
 
-The contribution guide also has more tips on our [development workflow](https://github.com/datproject/dat/blob/master/CONTRIBUTING.md#development-workflow).
+The contribution guide also has more tips on our [development workflow].
 
 * `npm run test` to run tests
 * `npm run auth-server` to run a local auth server for testing
@@ -456,3 +456,32 @@ The contribution guide also has more tips on our [development workflow](https://
 ## License
 
 BSD-3-Clause
+
+[Dat Project]: https://datproject.org
+[Code for Science & Society]: https://codeforscience.org
+[Dat white paper]: https://github.com/datproject/docs/blob/master/papers/dat-paper.pdf
+[Dat Desktop]: https://datproject.org/install#desktop
+[Beaker Browser]: https://beakerbrowser.com
+[registry server]: https://github.com/datproject/datproject.org
+[share-gif]: https://raw.githubusercontent.com/datproject/docs/master/assets/cli-share.gif
+[clone-gif]: https://raw.githubusercontent.com/datproject/docs/master/assets/cli-clone.gif
+[Knight Foundation grant]: https://datproject.org/blog/2016-02-01-announcing-publicbits
+[dat-node]: https://github.com/datproject/dat-node
+[dat-ignore]: https://github.com/joehand/dat-ignore
+[new-issue]: https://github.com/datproject/dat/issues/new
+[dat#503]: https://github.com/datproject/dat/issues/503
+[install-node]: https://nodejs.org/en/download/
+[install-node-npm]: https://docs.npmjs.com/getting-started/installing-node
+[fixing-npm-permissions]: https://docs.npmjs.com/getting-started/fixing-npm-permissions
+[guidelines on contributing]: https://github.com/datproject/dat/blob/master/CONTRIBUTING.md
+[development workflow]: https://github.com/datproject/dat/blob/master/CONTRIBUTING.md#development-workflow
+[travis-badge]: https://travis-ci.org/datproject/dat.svg?branch=master
+[travis-build]: https://travis-ci.org/datproject/dat
+[appveyor-badge]: https://ci.appveyor.com/api/projects/status/github/datproject/dat?branch=master&svg=true
+[appveyor-build]: https://ci.appveyor.com/project/joehand/dat/branch/master
+[npm-badge]: https://img.shields.io/npm/v/dat.svg
+[npm-package]: https://npmjs.org/package/dat
+[irc-badge]: https://img.shields.io/badge/irc%20channel-%23dat%20on%20freenode-blue.svg
+[irc-channel]: https://webchat.freenode.net/?channels=dat
+[gitter-badge]: https://badges.gitter.im/Join%20Chat.svg
+[gitter-chat]: https://gitter.im/datproject/discussions

--- a/README.md
+++ b/README.md
@@ -15,12 +15,12 @@ Have questions? Join our chat via IRC or Gitter:
 
 ### Table of Contents
 
-<li><a href="#installation">Installation</a></li>
-<li><a href="#getting-started">Getting Started</a></li>
-<li><a href="#usage">Using Dat</a></li>
-<li><a href="#troubleshooting">Troubleshooting</a></li>
-<li><a href="#js-api">Javascript API</a></li>
-<li><a href="#for-developers">For Developers</a></li>
+- [Installation](#installation)
+- [Getting Started](#getting-started)
+- [Using Dat](#usage)
+- [Troubleshooting](#troubleshooting)
+- [Javascript API](#js-api)
+- [For Developers](#for-developers)
 
 #### What is Dat?
 

--- a/README.md
+++ b/README.md
@@ -102,10 +102,10 @@ A dat is some files from your computer and a `.dat` folder. Each dat has a uniqu
 You can start sharing your files with a single command. Unlike `git`, you do not have to initialize a repository first, `dat share` will do that for you:
 
 ```
-dat share <folder>
+dat share <dir>
 ```
 
-Use `dat share` to create a dat and sync your files from your computer to other users. Dat scans your files inside `<folder>`, creating metadata in `<folder>/.dat`. Dat stores the public link, version history, and file information inside the dat folder.
+Use `dat share` to create a dat and sync your files from your computer to other users. Dat scans your files inside `<dir>`, creating metadata in `<dir>/.dat`. Dat stores the public link, version history, and file information inside the dat folder.
 
 ![share](https://raw.githubusercontent.com/datproject/docs/master/assets/cli-share.gif)
 
@@ -211,7 +211,7 @@ ADD: data/expn_cd.csv (403 MB / 920 MB)
 #### Creating a dat & dat.json
 
 ```
-dat create [<folder>]
+dat create [<dir>]
 ```
 
 The create command prompts you to make a `dat.json` file and creates a new dat. Import the files with sync or share.
@@ -220,7 +220,7 @@ The create command prompts you to make a `dat.json` file and creates a new dat. 
 #### Syncing to Network
 
 ```
-dat sync [<folder>] [--no-import] [--no-watch]
+dat sync [<dir>] [--no-import] [--no-watch]
 ```
 
 Start sharing your dat archive over the network.
@@ -246,7 +246,7 @@ By default, Dat will download all files. If you want to only download a subset, 
 Start downloading by running the `clone` command. This creates a folder, downloads the content and metadata, and a `.dat` folder inside. Once you started the download, you can resume using `clone` or the other download commands.
 
 ```
-dat clone <link> [<folder>] [--temp]
+dat clone <link> [<dir>] [--temp]
 ```
 
 Clone a remote dat archive to a local folder.
@@ -268,21 +268,21 @@ This will download the dat specified in the `dat.json` file.
 Once a dat is clone, you can run either `dat pull` or `dat sync` in the folder to update the archive.
 
 ```
-dat pull [<folder>]
+dat pull [<dir>]
 ```
 
 Update a cloned dat archive with the latest files and exit.
 
 ```
-dat sync [<folder>]
+dat sync [<dir>]
 ```
 
 Download latest files and keep connection open to continue updating as remote source is updated.
 
 ### Shortcut commands
 
-* `dat <link> <folder>` will run `dat clone` for new dats or resume the existing dat in `<folder>`
-* `dat <folder>` is the same as running `dat sync <folder>`
+* `dat <link> <dir>` will run `dat clone` for new dats or resume the existing dat in `<dir>`
+* `dat <dir>` is the same as running `dat sync <dir>`
 
 ### Dat Registry and Authentication
 


### PR DESCRIPTION
What this PR does:
- Fix typos/grammar
- Use HTTPS where possible
- Fix (all) Dat vs. dat spellings: Dat for the software name, dat for the dats themselves

I was also thinking of making editing easier by using [reference-style links]. Let me know if I should do that or not. It makes it easier to reuse links (e.g. to the [`dat-node`][dat-node] repo, which is linked a bunch of times).
(Mods, click `Edit` of this message, to see it in action!)

[reference-style links]: https://daringfireball.net/projects/markdown/syntax#link "Whoop!"
[dat-node]: https://github.com/datproject/dat-node