### PR TITLE
move discovery key to option

### DIFF
--- a/src/commands/keys.js
+++ b/src/commands/keys.js
@@ -11,7 +11,14 @@ module.exports = {
     '  dat keys import       import dat secret key to make a dat writable',
     ''
   ].join('\n'),
-  options: []
+  options: [
+    {
+      name: 'discovery',
+      boolean: true,
+      default: false,
+      help: 'Print Discovery Key'
+    }
+  ]
 }
 
 function keys (opts) {
@@ -40,7 +47,8 @@ function run (dat, opts) {
     root: {
       command: function () {
         console.log(`dat://${dat.key.toString('hex')}`)
-        console.log(`Discovery key: ${dat.archive.discoveryKey.toString('hex')}`)
+        if (opts.discovery) console.log(`Discovery key: ${dat.archive.discoveryKey.toString('hex')}`)
+        process.exit()
       }
     },
     commands: [

--- a/test/keys.js
+++ b/test/keys.js
@@ -16,6 +16,24 @@ test('keys - print keys', function (t) {
       var st = spawn(t, cmd, {cwd: fixtures})
 
       st.stdout.match(function (output) {
+        if (output.indexOf('dat://') === -1) return false
+        t.ok(output.indexOf(shareDat.key.toString('hex') > -1), 'prints key')
+        st.kill()
+        return true
+      })
+      st.stderr.empty()
+      st.end()
+    })
+  })
+})
+
+test('keys - print discovery key', function (t) {
+  help.shareFixtures(function (_, shareDat) {
+    shareDat.close(function () {
+      var cmd = dat + ' keys --discovery'
+      var st = spawn(t, cmd, {cwd: fixtures})
+
+      st.stdout.match(function (output) {
         if (output.indexOf('Discovery') === -1) return false
         t.ok(output.indexOf(shareDat.key.toString('hex') > -1), 'prints key')
         t.ok(output.indexOf(shareDat.archive.discoveryKey.toString('hex') > -1), 'prints discovery key')


### PR DESCRIPTION
* print dat key with `dat keys`
* print key + discovery key with `dat keys --discovery`

Makes it easy to get the key from a directory for other uses.