### PR TITLE
Add the packaging metadata to build the dat snap

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,23 @@
+name: dat
+version: master
+summary: Share & live sync files anywhere via command line
+description: |
+  A distributed data community. Dat is a nonprofit-backed community & open
+  protocol for building apps of the future.
+
+  Use Dat command line to share files with version control, back up data to
+  servers, browse remote files on demand, and automate long-term data
+  preservation.
+
+grade: devel # must be 'stable' to release into candidate/stable channels
+confinement: devmode # use 'strict' once you have the right plugs and slots
+
+apps:
+  dat:
+    command: dat
+    plugs: [home, network, network-bind]
+
+parts:
+  dat:
+    source: .
+    plugin: nodejs


### PR DESCRIPTION
This package will let you publish the latest dat in the Ubuntu store, and from there reach many users on all the supported Ubuntu versions, and [Linux distributions](https://docs.snapcraft.io/core/install). You just have to go to https://build.snapcraft.io and enable the automated continuous delivery.