### PR TITLE
show messsage if invalid dir name on createDir

### DIFF
--- a/src/commands/clone.js
+++ b/src/commands/clone.js
@@ -92,6 +92,9 @@ function clone (opts) {
       // Create the directory if it doesn't exist
       // If no dir is specified, we put dat in a dir with name = key
       if (!opts.dir) opts.dir = key
+      if (!Buffer.isBuffer(opts.dir) || typeof opts.dir !== 'string') {
+        return bus.emit('exit:error', 'Directory path must be a string or Buffer')
+      }
       fs.access(opts.dir, fs.F_OK, function (err) {
         if (!err) {
           createdDirectory = false

--- a/src/commands/clone.js
+++ b/src/commands/clone.js
@@ -92,7 +92,7 @@ function clone (opts) {
       // Create the directory if it doesn't exist
       // If no dir is specified, we put dat in a dir with name = key
       if (!opts.dir) opts.dir = key
-      if (!Buffer.isBuffer(opts.dir) || typeof opts.dir !== 'string') {
+      if (!Buffer.isBuffer(opts.dir) && typeof opts.dir !== 'string') {
         return bus.emit('exit:error', 'Directory path must be a string or Buffer')
       }
       fs.access(opts.dir, fs.F_OK, function (err) {


### PR DESCRIPTION
Hi, Dat people!

I saw an error with wrong argument to clone sample.
How do you like to show a message to get valid argument?

```console
$ dat clone dat://xxxx 2017
fs.js:288
  binding.access(pathModule._makeLong(path), mode, req);
          ^

TypeError: path must be a string or Buffer
    at Object.fs.access (fs.js:288:11)
    at createDir (/Users/tgfjt/workspace/dat/src/commands/clone.js:95:10)
    at /Users/tgfjt/workspace/dat/src/commands/clone.js:84:7
    at /Users/tgfjt/workspace/dat/node_modules/dat-link-resolve/index.js:34:23
    at /Users/tgfjt/workspace/dat/node_modules/call-me-maybe/index.js:11:28
    at _combinedTickCallback (internal/process/next_tick.js:95:7)
    at process._tickCallback (internal/process/next_tick.js:161:9)
    at Function.Module.runMain (module.js:607:11)
    at startup (bootstrap_node.js:158:16)
    at bootstrap_node.js:575:3
```