### PR TITLE
Enhanced `dat share` output

### DIFF
--- a/src/commands/share.js
+++ b/src/commands/share.js
@@ -30,6 +30,8 @@ module.exports = {
 }
 
 function share (opts) {
+  var path = require('path')
+  var fs = require('fs')
   var Dat = require('dat-node')
   var neatLog = require('neat-log')
   var archiveUI = require('../ui/archive')
@@ -55,6 +57,18 @@ function share (opts) {
       if (err && err.name === 'IncompatibleError') return bus.emit('exit:warn', 'Directory contains incompatible dat metadata. Please remove your old .dat folder (rm -rf .dat)')
       else if (err) return bus.emit('exit:error', err)
       if (!dat.writable && !opts.shortcut) return bus.emit('exit:warn', 'Archive not writable, cannot use share. Please use sync to resume download.')
+
+      fs.readFile(path.join(opts.dir, 'dat.json'), 'utf-8', (err, data) => {
+        if (err || !data) return setMetadata()
+        data = JSON.parse(data)
+        debug('read existing dat.json data', data)
+        setMetadata(data)
+      })
+
+      function setMetadata (data) {
+        if (!data) data = {}
+        else if (data.url) dat.metadata = data // valid dat file found, and assigned
+      }
 
       state.dat = dat
       bus.emit('dat')

--- a/src/ui/archive.js
+++ b/src/ui/archive.js
@@ -7,6 +7,7 @@ var warningsUI = require('./components/warnings')
 var networkUI = require('./components/network')
 var sourcesUI = require('./components/sources')
 var keyEl = require('./elements/key')
+var metadata = require('./elements/metadata')
 var pluralize = require('./elements/pluralize')
 var version = require('./elements/version')
 var pkg = require('../../package.json')
@@ -27,8 +28,10 @@ function archiveUI (state) {
     title += `${keyEl(dat.key)}\n`
   }
   if (state.title) title += state.title
-  else if (state.writable) title += 'Sharing dat'
-  else title += 'Downloading dat'
+  else if (state.writable) {
+    title += 'Sharing dat'
+    if (dat.metadata) title += `: ${metadata(dat.metadata)}\nFiles`
+  } else title += 'Downloading dat'
   if (state.opts.sparse) title += `: ${state.opts.selectedFiles.length} ${pluralize('file', state.opts.selectedFiles.length)} (${pretty(state.selectedByteLength)})`
   else if (stats.version > 0) title += `: ${stats.files} ${pluralize('file', stats.file)} (${pretty(stats.byteLength)})`
   else if (stats.version === 0) title += ': (empty archive)'

--- a/src/ui/elements/metadata.js
+++ b/src/ui/elements/metadata.js
@@ -1,0 +1,6 @@
+var chalk = require('chalk')
+
+module.exports = function (metadata) {
+  return `${chalk.magenta(`${metadata.title || 'No title'}`)}
+    ${chalk.dim(`${metadata.description || 'No description'}`)}`
+}


### PR DESCRIPTION
**This PR primarily adds metadata from dat.json (if found) to the archive view (used in `dat share`)** (ffa216c)(#879)**.**

If **no valid dat.json file is found**, then the view remains **unchanged**. In this case, a **valid dat.json file** is a dat.json file with a `url` key (both `title` and `description` are optional keys, whereas the `url` key is persistent). This validation is hacky, but it works.
If a valid dat.json file is found, it relays that metadata to the view, and renders it.

**Screenshot:**
<img width="561" alt="screen shot 2017-12-02 at 1 58 22 pm" src="https://user-images.githubusercontent.com/4392350/33520363-673102e0-d76e-11e7-966e-94258f1fd777.png">

**Examples:**
_no dat.json found_
```
Sharing dat: (empty archive)
```

_dat.json found, title only_
```
Sharing dat: <title here>
No description
Files: 1 file (126 B)
```
Additionally, I noticed a pluralization error when only 1 file was being shared (0cd591c).

_dat.json found, title & description_
```
Sharing dat: <title here>
<description here>
Files: 1 file (126 B)
```

_dat.json found, no title w/ description_
```
Sharing dat: No title
<description here>
Files: 1 file (139 B)
```

I used the same `chalk.magenta()` from the `dat create` sequence in an attempt to provide visual cohesion, as well as ease of identification.

---

Obviously, as the files within the dat change, the _title_ and _description_ scroll out of view because of the growing changelog. In the future, I'd like to maybe see the _title_ and _description_ constantly at the bottom of the view, and the recent changes listed reverse chronologically above that.