### PR TITLE
binary release fixes + install info

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ test/**.db
 test/.datrc-test
 package-lock.json
 dist
+builds

--- a/INSTALL
+++ b/INSTALL
@@ -1,0 +1,26 @@
+Dat CLI installation instructions
+
+Method 1: Self contained binary
+
+- This method does not require installing Node.js or npm
+- Download the latest release zip for your platform (self contained binary) from https://github.com/datproject/dat/releases
+- Extract the zip
+- On a command line run: ./path-to-extracted-zip/dat
+- Make sure to leave all files in the extracted zip in their original location
+
+Linux/Mac: Add to your PATH so you can just run 'dat' instead of './path-to-extracted-zip/dat':
+
+- On a command line run: cd ./path-to-extracted-zip
+- Run: pwd
+- Use the path printed out above to add this line to your `.bash_profile', e.g.:
+
+PATH=/Users/maxogden/Downloads/dat-13.9.2-macos-x64/:$PATH
+
+- Reload your terminal and you should just be able to run 'dat' from any folder now.
+
+Method 2 (recommended for easy updates): npm
+
+- Install http://nodejs.org/
+- On a command line run: npm install dat --global
+- You should now have dat installed, try running: dat
+

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "hypercore": "^6.5.0",
     "hyperdiscovery": "^7.0.0",
     "mkdirp": "^0.5.1",
-    "pkg": "^4.2.2",
+    "pkg": "^4.2.6",
     "random-access-memory": "^2.4.0",
     "recursive-readdir-sync": "^1.0.6",
     "request": "^2.81.0",
@@ -73,8 +73,8 @@
   },
   "pkg": {
     "assets": [
-      "node_modules/utp-native/prebuilds/**",
-      "node_modules/sodium-native/prebuilds/**"
+      "./node_modules/blake2b-wasm/blake2b.wasm",
+      "./node_modules/siphash24/siphash24.wasm"
     ],
     "targets": [
       "node8-linux-x64",

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
   },
   "pkg": {
     "assets": [
+      "./node_modules/utp-native/prebuilds/**",
       "./node_modules/blake2b-wasm/blake2b.wasm",
       "./node_modules/siphash24/siphash24.wasm"
     ],

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "deps": "dependency-check . && dependency-check . --extra --no-dev",
     "test": "standard && npm run deps && tape 'test/*.js'",
     "test-only": "tape 'test/*.js'",
-    "package": "pkg package.json -o dist/dat"
+    "package": "rm -rf builds && npm run pkg && ./package.sh",
+    "pkg": "pkg package.json -o builds/dat"
   },
   "repository": {
     "type": "git",
@@ -58,6 +59,7 @@
     "xtend": "^4.0.1"
   },
   "devDependencies": {
+    "cross-zip-cli": "^1.0.0",
     "dependency-check": "^2.8.0",
     "hypercore": "^6.5.0",
     "hyperdiscovery": "^7.0.0",

--- a/package.sh
+++ b/package.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env sh
+# couldnt figure out undocumented 'output template' mode for pkg so wrote this
+# also need to include .node files until pkg supports including them in binary
+
+NODE_ABI="node-57"
+VERSION=$(node -pe "require('./package.json').version")
+
+rm -rf dist
+
+mkdir dist
+mkdir builds/dat-$VERSION-linux-x64
+mkdir builds/dat-$VERSION-macos-x64
+mkdir builds/dat-$VERSION-win-x64
+
+mv builds/dat-linux builds/dat-$VERSION-linux-x64/dat
+mv builds/dat-macos builds/dat-$VERSION-macos-x64/dat
+mv builds/dat-win.exe builds/dat-$VERSION-win-x64/dat.exe
+
+cp node_modules/utp-native/prebuilds/linux-x64/$NODE_ABI.node builds/dat-$VERSION-linux-x64/
+cp node_modules/utp-native/prebuilds/darwin-x64/$NODE_ABI.node builds/dat-$VERSION-macos-x64/
+cp node_modules/utp-native/prebuilds/win32-x64/$NODE_ABI.node builds/dat-$VERSION-win-x64/
+
+cp LICENSE builds/dat-$VERSION-linux-x64/
+cp LICENSE builds/dat-$VERSION-macos-x64/
+cp LICENSE builds/dat-$VERSION-win-x64/
+
+cp INSTALL builds/dat-$VERSION-linux-x64/README
+cp INSTALL builds/dat-$VERSION-macos-x64/README
+cp INSTALL builds/dat-$VERSION-win-x64/README
+
+cd builds
+../node_modules/.bin/cross-zip dat-$VERSION-linux-x64 ../dist/dat-$VERSION-linux-x64.zip
+../node_modules/.bin/cross-zip dat-$VERSION-macos-x64 ../dist/dat-$VERSION-macos-x64.zip
+../node_modules/.bin/cross-zip dat-$VERSION-win-x64 ../dist/dat-$VERSION-win-x64.zip
+
+rm -rf builds
+
+# now travis will upload the 3 zips in dist to the release


### PR DESCRIPTION
Finishing support for Dat binary releases! The last issue is getting UTP native included in the release. Right now pkg doesn't [support including native modules](https://github.com/zeit/pkg/issues/329) in the package, so we'll put the binary plus `.node` file together in a folder for folks to download.

- [x] get WASM builds in binary
- [x] add native modules to travis release thing
- [x] add install info to readme
- [ ] add download button to docs
- [x] write basic install script (?)

ARM builds have a few blockers:

* https://github.com/zeit/pkg-fetch/issues/31
* (another issue I need to find)