### PR TITLE
Fix passing in <key> to `dat doctor <key>`

### DIFF
--- a/src/commands/doctor.js
+++ b/src/commands/doctor.js
@@ -11,7 +11,7 @@ module.exports = {
   command: function (opts) {
     var doctor = require('dat-doctor')
 
-    opts.id = opts._[0]
+    opts.peerId = opts._[0]
     doctor(opts)
   }
 }


### PR DESCRIPTION
I was testing docs, and I noticed that the new version of dat with the upgraded dat-doctor wasn't passing the key argument through...

```
jim@jpimac ~ $ dat doctor f00188881fab8fe50d36b9d20ae53be8c5127160a22034b3687670835e2f59aa
Welcome to Dat Doctor!

Software Info:
  darwin x64
  Node v10.3.0
  Dat Doctor v2.0.0
  dat v13.11.2

Which tests would you like to run?
> Basic Tests (Checks your Dat installation and network setup)
  Peer-to-Peer Test (Debug connections between two computers)
```