### PR TITLE
Clarify dat create title, description, & yes

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,27 @@ Once a dat is created, you can run all the commands inside that folder, similar 
 
 Dat keeps secret keys in the `~/.dat/secret_keys` folder. These are required to write to any dats you create.
 
+#### Creating a dat & dat.json
+
+```
+dat create [<dir>]
+```
+
+The create command prompts you to make a `dat.json` file and creates a new dat. Import the files with sync or share.
+
+Optionally bypass Title and Description prompt:
+
+```sh
+dat create --title "MY BITS" --description "are ready to synchronize! 😎"
+```
+
+Optionally bypass `dat.json` creation:
+
+```sh
+dat create --yes
+dat create -y
+```
+
 ### Sharing
 
 The quickest way to get started sharing files is to `share`:
@@ -213,16 +234,6 @@ Importing 528 files to Archive (165 MB/s)
 [=-----------------------------------------] 3%
 ADD: data/expn_cd.csv (403 MB / 920 MB)
 ```
-
-
-#### Creating a dat & dat.json
-
-```
-dat create [<dir>]
-```
-
-The create command prompts you to make a `dat.json` file and creates a new dat. Import the files with sync or share.
-
 
 #### Syncing to Network
 

--- a/src/commands/create.js
+++ b/src/commands/create.js
@@ -13,6 +13,14 @@ module.exports = {
       default: false,
       abbr: 'y',
       help: 'Skip dat.json creation.'
+    },
+    {
+      name: 'title',
+      help: 'the title property for dat.json'
+    },
+    {
+      name: 'description',
+      help: 'the description property for dat.json'
     }
   ]
 }


### PR DESCRIPTION
## What does it do?

+ Docs: `dat create` goes above `dat sync` in Usage section in Readme
+ `--yes|-y`, `title`, `description` CLI instructions added
+ title and description added to `dat create --help`

## How to test

```sh
git clone -b docs-dat-create-options https://github.com/tcrowe/dat.git tcrowe-dat
cd tcrowe-dat
npm install
npm test
```

```text
1..136
# tests 136
# pass  136

# ok
```

The title and description were already being used in the tests.