### PR TITLE
Added support for dat-store, fixed up extensions

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -75,7 +75,7 @@ var config = {
     require('../src/commands/auth/login')
   ],
   usage: {
-    command: usage,
+    command: showUsageOrRunExtension,
     option: {
       name: 'help',
       abbr: 'h'
@@ -84,7 +84,10 @@ var config = {
   aliases: {
     'init': 'create'
   },
-  extensions: [] // whitelist extensions for now
+  // whitelist extensions for now
+  extensions: [
+    'store'
+  ]
 }
 
 if (debug.enabled) {
@@ -140,6 +143,12 @@ function syncShorthand (opts) {
 
   // All else fails, show usage
   return usage(opts)
+}
+
+// This was needed so that we can show help messages from extensions
+function showUsageOrRunExtension (opts, help, usageMessage) {
+  if (config.extensions.indexOf(opts._[0]) > -1) return require('../src/extensions')(opts)
+  usage(opts, help, usageMessage)
 }
 
 function exitInvalidNode () {

--- a/src/extensions.js
+++ b/src/extensions.js
@@ -16,7 +16,7 @@ function runExtension (opts) {
   function trySpawn (cb) {
     var spawn = require('child_process').spawn
     var name = 'dat-' + extName
-    if(os.platform() === 'win32') {
+    if (os.platform() === 'win32') {
       name += '.cmd'
     }
     var child = spawn(name, process.argv.splice(3))

--- a/src/extensions.js
+++ b/src/extensions.js
@@ -1,4 +1,5 @@
 var debug = require('debug')('dat')
+var os = require('os')
 
 module.exports = runExtension
 
@@ -14,7 +15,11 @@ function runExtension (opts) {
 
   function trySpawn (cb) {
     var spawn = require('child_process').spawn
-    var child = spawn('dat-' + extName, process.argv.splice(3))
+    var name = 'dat-' + extName
+    if(os.platform() === 'win32') {
+      name += '.cmd'
+    }
+    var child = spawn(name, process.argv.splice(3))
     child.stdout.pipe(process.stdout)
     child.stderr.pipe(process.stderr)
     child.on('error', function (err) {


### PR DESCRIPTION
- Fixes extensions not being able to show help messages
- Fixes launching extensions on Windows (it needed to be spawned as `.cmd`)
- Adds support for the `dat-store` extension