### PR TITLE
Fix issue #1089 - Add "--exit" support to "dat pull" command 

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 *Note: unreleased changes are added here.*
+* dat pull --exit properly exits when there are no updates to sync.
 
 ## 13.9.0 - 2017-10-11
 

--- a/src/commands/pull.js
+++ b/src/commands/pull.js
@@ -8,6 +8,12 @@ module.exports = {
   ].join('\n'),
   options: [
     {
+      name: 'exit',
+      boolean: true,
+      default: false,
+      help: 'sync and exit immediately.'
+    },
+    {
       name: 'upload',
       boolean: true,
       default: true,
@@ -58,7 +64,6 @@ function pull (opts) {
 
   // Force these options for pull command
   opts.createIfMissing = false
-  opts.exit = true
 
   var neat = neatLog(archiveUI, { logspeed: opts.logspeed, quiet: opts.quiet, debug: opts.debug })
   neat.use(trackArchive)

--- a/src/lib/download.js
+++ b/src/lib/download.js
@@ -32,7 +32,14 @@ function trackDownload (state, bus) {
     archive.on('sync', function () {
       debug('archive sync', state.stats.get())
       state.download.nsync = true
-      if (state.opts.exit) return exit()
+      // if we are supposed to exit, do so if we've pulled changes or have given the network 12 seconds
+      if (state.opts.exit) {
+        if (state.download.modified) {
+          return exit()
+        } else {
+          setTimeout(exit, 12000);
+        }
+      }
       if (state.dat.archive.version === 0) {
         // TODO: deal with this.
         // Sync sometimes fires early when it should wait for update.

--- a/src/lib/download.js
+++ b/src/lib/download.js
@@ -37,7 +37,7 @@ function trackDownload (state, bus) {
         if (state.download.modified) {
           return exit()
         } else {
-          setTimeout(exit, 12000);
+          setTimeout(exit, 12000)
         }
       }
       if (state.dat.archive.version === 0) {

--- a/src/lib/download.js
+++ b/src/lib/download.js
@@ -32,8 +32,7 @@ function trackDownload (state, bus) {
     archive.on('sync', function () {
       debug('archive sync', state.stats.get())
       state.download.nsync = true
-      var shouldExit = (state.download.modified && state.opts.exit)
-      if (shouldExit) return exit()
+      if (state.opts.exit) return exit()
       if (state.dat.archive.version === 0) {
         // TODO: deal with this.
         // Sync sometimes fires early when it should wait for update.

--- a/src/ui/components/download.js
+++ b/src/ui/components/download.js
@@ -21,7 +21,7 @@ function networkUI (state) {
 
     if (!download.modified) {
       if (state.opts.exit) {
-        title = `dat already in sync`
+        title = `dat already in sync, exiting in 12 seconds`
       } else {
         title = `dat already in sync, waiting for updates.`
       }

--- a/src/ui/components/download.js
+++ b/src/ui/components/download.js
@@ -22,8 +22,7 @@ function networkUI (state) {
     if (!download.modified) {
       if (state.opts.exit) {
         title = `dat already in sync`
-      }
-      else {
+      } else {
         title = `dat already in sync, waiting for updates.`
       }
     } else {

--- a/src/ui/components/download.js
+++ b/src/ui/components/download.js
@@ -19,8 +19,13 @@ function networkUI (state) {
       return `dat sync complete.\nVersion ${stats.version}`
     }
 
-    if (!download.modified && state.opts.exit) {
-      title = `dat already in sync, waiting for updates.`
+    if (!download.modified) {
+      if (state.opts.exit) {
+        title = `dat already in sync`
+      }
+      else {
+        title = `dat already in sync, waiting for updates.`
+      }
     } else {
       title = `dat synced, waiting for updates.`
     }


### PR DESCRIPTION
In the screenshot below, you'll see the effects of this patch. In particular:

* The updated help for "--exit"
* Running "dat pull --exit" and exiting when there are no updates
* Running "dat pull" and NOT exiting when there are no updates.

![image](https://user-images.githubusercontent.com/100404/55600502-40dd5200-572a-11e9-995b-d065a816b0ff.png)
