### PR TITLE
modify --exit for dat pull command, so that it exits after specified …

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
-*Note: unreleased changes are added here.*
+* `dat pull --exit=NN` exits after `NN` number of seconds, when there are no updates to sync.
 
 ## 13.9.0 - 2017-10-11
 

--- a/src/commands/pull.js
+++ b/src/commands/pull.js
@@ -8,6 +8,12 @@ module.exports = {
   ].join('\n'),
   options: [
     {
+      name: 'exit',
+      boolean: false,
+      help: 'exit after specified number of seconds (gives the dat network time to find updates). defaults to 12 seconds.'
+    },
+
+    {
       name: 'upload',
       boolean: true,
       default: true,
@@ -58,7 +64,11 @@ function pull (opts) {
 
   // Force these options for pull command
   opts.createIfMissing = false
-  opts.exit = true
+
+  // If --exit is specified without a number of seconds, default to 12
+  if (opts.exit === true) {
+    opts.exit = 12
+  }
 
   var neat = neatLog(archiveUI, { logspeed: opts.logspeed, quiet: opts.quiet, debug: opts.debug })
   neat.use(trackArchive)

--- a/src/lib/download.js
+++ b/src/lib/download.js
@@ -32,8 +32,15 @@ function trackDownload (state, bus) {
     archive.on('sync', function () {
       debug('archive sync', state.stats.get())
       state.download.nsync = true
-      var shouldExit = (state.download.modified && state.opts.exit)
-      if (shouldExit) return exit()
+      // if we are supposed to exit, do so if we've pulled changes or have given the network the desired wait time
+      if (state.opts.exit) {
+        if (state.download.modified) {
+          return exit()
+        } else {
+          var delayInMilliseconds = 1000 * state.opts.exit
+          setTimeout(exit, delayInMilliseconds)
+        }
+      }
       if (state.dat.archive.version === 0) {
         // TODO: deal with this.
         // Sync sometimes fires early when it should wait for update.

--- a/src/ui/components/download.js
+++ b/src/ui/components/download.js
@@ -26,6 +26,10 @@ function networkUI (state) {
     }
   }
 
+  if (state.opts.exit) {
+    title = `dat synced, exiting in ${state.opts.exit} seconds.`
+  }
+
   if (!stats.downloaded || !stats.length) {
     return '' // no metadata yet
   }


### PR DESCRIPTION
…number of seconds, when there are no updates to sync.

Sample usage:

![image](https://user-images.githubusercontent.com/100404/56259636-bbe72680-60a1-11e9-9ec0-638fd45db196.png)
