### PR TITLE
Link to new dat-logo.png

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Dat is a nonprofit-backed community & open protocol for building apps of the fut
 
 Use Dat command line to share files with version control, back up data to servers, browse remote files on demand, and automate long-term data preservation.
 
-[<img src="https://datproject.github.io/design/downloads/dat-data-logo.png" align="right" width="140">][Dat Project]
+[<img src="https://datproject.github.io/design/downloads/dat-logo.png" align="right" width="140">][Dat Project]
 
 Have questions? Join our chat via IRC or Gitter:
 


### PR DESCRIPTION
Reflects https://github.com/datproject/design/commit/7f024eabb22f4843230cab8db1ffd1f819c99d06 , which removed dat-data-logo.png and added dat-logo.png.

See also https://github.com/datproject/design/pull/33