### PR TITLE
Updated link for Dat Desktop

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Dat allows you to focus on the fun work without worrying about moving files arou
 Rather not use the command line? Check out these options:
 
 * [Beaker Browser] - An experimental p2p browser with built-in support for the Dat protocol.
-* [Dat Desktop] - A desktop app to manage multiple dats on your desktop machine. 
+* [Dat Desktop](https://github.com/datproject/dat-desktop) - A desktop app to manage multiple dats on your desktop machine. 
 
 ## dat command line
 


### PR DESCRIPTION
As per issue https://github.com/datproject/dat/issues/1178

Updating the link for Dat Desktop to point to its project page on Github. Otherwise, it's pointing to an anchor in the docs that doesn't exist.

If PRing from my master to yours isn't okay just let me know :)