### PR TITLE
fix: Use the NODE_VERSION_SUPPORTED variable on exit message.

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -153,7 +153,7 @@ function showUsageOrRunExtension (opts, help, usageMessage) {
 
 function exitInvalidNode () {
   console.error('Node Version:', process.version)
-  console.error('Unfortunately, we only support Node >= v4. Please upgrade to use Dat.')
+  console.error(`Unfortunately, we only support Node >= v${NODE_VERSION_SUPPORTED}. Please upgrade to use Dat.`)
   console.error('You can find the latest version at https://nodejs.org/')
   process.exit(0)
 }


### PR DESCRIPTION
Replaced the literal 4 with NODE_VERSION_SUPPORTED  template.